### PR TITLE
Test fixes

### DIFF
--- a/a10_neutron_lbaas/v2/handler_hm.py
+++ b/a10_neutron_lbaas/v2/handler_hm.py
@@ -37,12 +37,18 @@ class HealthMonitorHandler(handler_base_v2.HandlerBaseV2):
             url = hm.url_path
             expect_code = hm.expected_codes
 
+        self._ensure_timeout_does_not_exceed_delay(hm)
+
         args = self.meta(hm, 'hm', {})
 
         set_method(hm_name, a10_os.hm_type(c, hm.type),
                    hm.delay, hm.timeout, hm.max_retries,
                    method=method, url=url, expect_code=expect_code,
                    axapi_args=args)
+
+    def _ensure_timeout_does_not_exceed_delay(self, hm):
+        if hm.delay < hm.timeout and hm.timeout > 0:
+            hm.delay = hm.timeout
 
     def create(self, context, hm):
         with a10.A10WriteStatusContext(self, context, hm) as c:

--- a/a10_neutron_lbaas/v2/handler_hm.py
+++ b/a10_neutron_lbaas/v2/handler_hm.py
@@ -51,6 +51,7 @@ class HealthMonitorHandler(handler_base_v2.HandlerBaseV2):
             hm.delay = hm.timeout
 
     def create(self, context, hm):
+        LOG.debug("HealthMonitorHandler.create(): hm=%s, context=%s" % (dir(hm), context))
         with a10.A10WriteStatusContext(self, context, hm) as c:
             for i in range(0, 2):
                 try:
@@ -81,12 +82,13 @@ class HealthMonitorHandler(handler_base_v2.HandlerBaseV2):
             self._set(c, c.client.slb.hm.update, context, hm)
 
     def _delete(self, c, context, hm):
-        LOG.debug("HealthMonitorHandler.delete(): hm=%s" % (hm))
-        with a10.A10WriteStatusContext(self, context, hm.pool) as wc:
-            LOG.debug("HealthMonitorHandler.delete(): Updating...")
-            pool_name = self._pool_name(context, pool=hm.pool)
-            wc.client.slb.service_group.update(pool_name, health_monitor="",
-                                               health_monitor_disable=True)
+        LOG.debug("HealthMonitorHandler.delete(): hm=%s, context=%s" % (dir(hm), context))
+
+        # with a10.A10WriteContext(self, context, hm.pool) as wc:
+        LOG.debug("HealthMonitorHandler.delete(): Updating...")
+        pool_name = self._pool_name(context, pool=hm.pool)
+        c.client.slb.service_group.update(pool_name, health_monitor="",
+                                          health_monitor_disable=True)
         c.client.slb.hm.delete(self._meta_name(hm))
 
     def delete(self, context, hm):

--- a/a10_neutron_lbaas/v2/handler_hm.py
+++ b/a10_neutron_lbaas/v2/handler_hm.py
@@ -58,20 +58,20 @@ class HealthMonitorHandler(handler_base_v2.HandlerBaseV2):
 
             c.client.slb.service_group.update(
                 self._pool_name(context, pool=hm.pool),
-                health_monitor=self._meta_name(hm), health_monitor_disable=0)
+                health_monitor=self._meta_name(hm), health_monitor_disable=False)
 
     def update(self, context, old_hm, hm):
         with a10.A10WriteStatusContext(self, context, hm) as c:
             if old_hm.pool and not hm.pool:
                 pool_name = self._pool_name(context, pool=old_hm.pool)
-                c.client.slb.service_group.update(pool_name, 
-                                                  health_monitor="", 
-                                                  health_monitor_disable=1)
+                c.client.slb.service_group.update(pool_name,
+                                                  health_monitor="",
+                                                  health_monitor_disable=True)
             elif old_hm.pool != hm.pool:
                 pool_name = self._pool_name(context, pool=hm.pool)
                 c.client.slb.service_group.update(pool_name,
                                                   health_monitor=self._meta_name(hm),
-                                                  health_monitor_disable=0)
+                                                  health_monitor_disable=False)
             self._set(c, c.client.slb.hm.update, context, hm)
 
     def _delete(self, c, context, hm):
@@ -80,7 +80,7 @@ class HealthMonitorHandler(handler_base_v2.HandlerBaseV2):
             LOG.debug("HealthMonitorHandler.delete(): Updating...")
             pool_name = self._pool_name(context, pool=hm.pool)
             wc.client.slb.service_group.update(pool_name, health_monitor="",
-                                               health_monitor_disable=1)
+                                               health_monitor_disable=True)
         c.client.slb.hm.delete(self._meta_name(hm))
 
     def delete(self, context, hm):

--- a/a10_neutron_lbaas/v2/handler_pool.py
+++ b/a10_neutron_lbaas/v2/handler_pool.py
@@ -13,6 +13,7 @@
 #    under the License.
 
 import logging
+import copy
 
 from a10_neutron_lbaas import a10_openstack_map as a10_os
 import acos_client.errors as acos_errors
@@ -67,7 +68,9 @@ class PoolHandler(handler_base_v2.HandlerBaseV2):
             for member in pool.members:
                 self.a10_driver.member._delete(c, context, member)
 
+            LOG.debug("handler_pool.delete(): Checking pool health monitor...")
             if pool.healthmonitor:
+                LOG.debug("handler_pool.delete(): HM: %s" % (pool.healthmonitor))
                 self.a10_driver.hm._delete(c, context, pool.healthmonitor)
 
             c.client.slb.service_group.delete(self._meta_name(pool))

--- a/a10_neutron_lbaas/v2/handler_pool.py
+++ b/a10_neutron_lbaas/v2/handler_pool.py
@@ -13,7 +13,6 @@
 #    under the License.
 
 import logging
-import copy
 
 from a10_neutron_lbaas import a10_openstack_map as a10_os
 import acos_client.errors as acos_errors

--- a/a10_neutron_lbaas/version.py
+++ b/a10_neutron_lbaas/version.py
@@ -1,1 +1,1 @@
-VERSION = "1.3.3"
+VERSION = "1.3.4"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-acos_client>=1.2.4
+acos_client>=1.2.6

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "a10-neutron-lbaas",
-    version = "1.3.3",
+    version = "1.3.4",
     packages = find_packages(),
 
     author = "A10 Networks",

--- a/setup.py
+++ b/setup.py
@@ -26,5 +26,5 @@ setup(
         'Topic :: Internet',
     ],
 
-    install_requires = ['acos-client>=1.2.4']
+    install_requires = ['acos-client>=1.2.6']
 )

--- a/tests/unit/v2/test_base.py
+++ b/tests/unit/v2/test_base.py
@@ -98,7 +98,7 @@ class FakeHM(FakeModel):
         self.id = 'fake-hm-id-001'
         self.name = 'hm1'
         self.type = prot
-        self.delay = 6
+        self.delay = 7
         self.timeout = 7
         self.max_retries = 8
         self.http_method = 'GET'

--- a/tests/unit/v2/test_handler_hm.py
+++ b/tests/unit/v2/test_handler_hm.py
@@ -51,7 +51,7 @@ class TestHM(test_base.UnitTestBase):
         self.a.hm.create(None, m)
         self.assert_hm(m, self.a.last_client.slb.hm.HTTP, 'GET', '/', '200')
         self.a.last_client.slb.service_group.update.assert_called_with(
-            m.pool.id, health_monitor='fake-hm-id-001')
+            m.pool.id, health_monitor='fake-hm-id-001', health_monitor_disable=False)
 
     def test_update_tcp(self, m_old=None, m=None):
         if m_old is None:
@@ -71,14 +71,14 @@ class TestHM(test_base.UnitTestBase):
         self.test_update_tcp(m=m)
         self.print_mocks()
         self.a.last_client.slb.service_group.update.assert_called_with(
-            m.pool.id, health_monitor='fake-hm-id-001')
+            m.pool.id, health_monitor='fake-hm-id-001', health_monitor_disable=False)
 
     def test_update_tcp_delete_pool(self):
         m_old = test_base.FakeHM('TCP', pool=mock.MagicMock())
         self.test_update_tcp(m_old=m_old)
         self.print_mocks()
         self.a.last_client.slb.service_group.update.assert_called_with(
-            m_old.pool.id, health_monitor='')
+            m_old.pool.id, health_monitor='', health_monitor_disable=True)
 
     def test_delete(self):
         m = test_base.FakeHM('HTTP')

--- a/tests/unit/v2/test_handler_hm.py
+++ b/tests/unit/v2/test_handler_hm.py
@@ -93,5 +93,5 @@ class TestHM(test_base.UnitTestBase):
         self.a.openstack_driver.health_monitor.successful_completion.assert_called_with(
             None, m, delete=True)
         self.a.last_client.slb.service_group.update.assert_called_with(
-            m.pool.id, health_monitor='')
+            m.pool.id, health_monitor='', health_monitor_disabled=True)
         self.a.last_client.slb.hm.delete.assert_called_with('fake-hm-id-001')

--- a/tests/unit/v2/test_handler_hm.py
+++ b/tests/unit/v2/test_handler_hm.py
@@ -91,6 +91,7 @@ class TestHM(test_base.UnitTestBase):
 
     def test_delete(self):
         m = test_base.FakeHM('HTTP')
+        self.a.hm.tenant_id = "tenant-id"
         self.a.hm.delete(None, m)
         self.a.openstack_driver.health_monitor.successful_completion.assert_called_with(
             None, m, delete=True)
@@ -102,5 +103,5 @@ class TestHM(test_base.UnitTestBase):
         self.a.openstack_driver.health_monitor.successful_completion.assert_called_with(
             None, m, delete=True)
         self.a.last_client.slb.service_group.update.assert_called_with(
-            m.pool.id, health_monitor='', health_monitor_disabled=True)
+            m.pool.id, health_monitor='', health_monitor_disable=True)
         self.a.last_client.slb.hm.delete.assert_called_with('fake-hm-id-001')

--- a/tests/unit/v2/test_handler_hm.py
+++ b/tests/unit/v2/test_handler_hm.py
@@ -22,7 +22,16 @@ class TestHM(test_base.UnitTestBase):
         self.a.openstack_driver.health_monitor.successful_completion.assert_called_with(
             None, model)
         self.a.last_client.slb.hm.create.assert_called_with(
-            'fake-hm-id-001', mon_type, 6, 7, 8,
+            'fake-hm-id-001', mon_type, 7, 7, 8,
+            method=method, url=url, expect_code=expect_code, axapi_args={})
+
+    def assert_create_sets_delay_timeout(self, model, mon_type, method, url, expect_code):
+        model.timeout = 10
+        model.delay = 6
+        self.a.openstack_driver.health_monitor.successful_completion.assert_called_with(
+            None, model)
+        self.a.last_client.slb.hm.create.assert_called_with(
+            'fake-hm-id-001', mon_type, model.delay, model.timeout, 8,
             method=method, url=url, expect_code=expect_code, axapi_args={})
 
     def test_create_ping(self):


### PR DESCRIPTION
These tests broke as a result of fixing the handler logic in neutron-lbaas and acos-client.  I made what seemed to be the appropriate modifications.  One issue is that these tests are not going to pass until the fixed version of the v2 driver in neutron-lbaas is merged in