### PR TITLE
Removed uphill creation of parent objects.

### DIFF
--- a/a10_neutron_lbaas/v2/handler_hm.py
+++ b/a10_neutron_lbaas/v2/handler_hm.py
@@ -58,15 +58,10 @@ class HealthMonitorHandler(handler_base_v2.HandlerBaseV2):
     def create(self, context, hm):
         LOG.debug("HealthMonitorHandler.create(): hm=%s, context=%s" % (dir(hm), context))
         with a10.A10WriteStatusContext(self, context, hm) as c:
-            for i in range(0, 2):
-                try:
-                    self._set(c, c.client.slb.hm.create, context, hm)
-                except acos_errors.Exists:
-                    pass
-                except acos_errors.NotFound:
-                    self.a10_driver.pool._create(c, context, hm.pool)
-                    continue
-                break
+            try:
+                self._set(c, c.client.slb.hm.create, context, hm)
+            except acos_errors.Exists:
+                pass
 
             # Disable any potentially existing health monitor.
             c.client.slb.service_group.update(

--- a/a10_neutron_lbaas/v2/handler_listener.py
+++ b/a10_neutron_lbaas/v2/handler_listener.py
@@ -79,13 +79,7 @@ class ListenerHandler(handler_base_v2.HandlerBaseV2):
 
     def create(self, context, listener):
         with a10.A10WriteStatusContext(self, context, listener) as c:
-            for i in range(0, 2):
-                try:
-                    self._create(c, context, listener)
-                except acos_errors.NotFound:
-                    self.a10_driver.loadbalancer._create(c, context, listener.loadbalancer)
-                    continue
-                break
+            self._create(c, context, listener)
 
     def _update(self, c, context, listener):
         self._set(c.client.slb.virtual_server.vport.update, c, context, listener)

--- a/a10_neutron_lbaas/v2/handler_member.py
+++ b/a10_neutron_lbaas/v2/handler_member.py
@@ -59,13 +59,7 @@ class MemberHandler(handler_base_v2.HandlerBaseV2):
 
     def create(self, context, member):
         with a10.A10WriteStatusContext(self, context, member) as c:
-            for i in range(0, 2):
-                try:
-                    self._create(c, context, member)
-                except acos_errors.NotFound:
-                    self.a10_driver.pool._create(c, context, member.pool)
-                    continue
-                break
+            self._create(c, context, member)
 
     def update(self, context, old_member, member):
         with a10.A10WriteStatusContext(self, context, member) as c:

--- a/a10_neutron_lbaas/v2/handler_pool.py
+++ b/a10_neutron_lbaas/v2/handler_pool.py
@@ -49,13 +49,11 @@ class PoolHandler(handler_base_v2.HandlerBaseV2):
 
     def create(self, context, pool):
         with a10.A10WriteStatusContext(self, context, pool) as c:
-            for i in range(0, 2):
-                try:
-                    self._create(c, context, pool)
-                except acos_errors.NotFound:
-                    self.a10_driver.listener._create(c, context, pool.listener)
-                    continue
-                break
+            try:
+                self._set(c.client.slb.service_group.create,
+                          c, context, pool)
+            except acos_errors.Exists:
+                pass
 
     def update(self, context, old_pool, pool):
         with a10.A10WriteStatusContext(self, context, pool) as c:


### PR DESCRIPTION
When we do this, the corresponding elements are NOT created in the neutron DB and that causes big problems.

Of 189 tests, we have...
170 Passing
7 Failing
12 skipped