### PR TITLE
Issue 87 - vports not correctly associated with service group on pool creation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ python: 2.7
 env:
   - TOX_ENV=py26
   - TOX_ENV=py27
-  - TOX_ENV=pypy
   - TOX_ENV=pep8
 install:
   - pip install tox

--- a/a10_neutron_lbaas/v2/handler_listener.py
+++ b/a10_neutron_lbaas/v2/handler_listener.py
@@ -34,8 +34,6 @@ class ListenerHandler(handler_base_v2.HandlerBaseV2):
         self.barbican_client = barbican_client
 
     def _set(self, set_method, c, context, listener):
-        import pdb
-        pdb.set_trace()
         if self.barbican_client is None:
             self.barbican_client = certwrapper.CertManagerWrapper()
 
@@ -89,7 +87,7 @@ class ListenerHandler(handler_base_v2.HandlerBaseV2):
         persistence = handler_persist.PersistHandler(
             c, context, listener.default_pool)
         vport_meta = self.meta(listener, 'port', {})
-        a10_common._set_auto_parameter(vport_meta, self.a10_driver.config)
+        a10_common._set_auto_parameter(vport_meta, c.device_cfg)
         vport_args = {'port': vport_meta}
 
         try:

--- a/a10_neutron_lbaas/v2/handler_listener.py
+++ b/a10_neutron_lbaas/v2/handler_listener.py
@@ -34,6 +34,8 @@ class ListenerHandler(handler_base_v2.HandlerBaseV2):
         self.barbican_client = barbican_client
 
     def _set(self, set_method, c, context, listener):
+        import pdb
+        pdb.set_trace()
         if self.barbican_client is None:
             self.barbican_client = certwrapper.CertManagerWrapper()
 

--- a/a10_neutron_lbaas/v2/handler_listener.py
+++ b/a10_neutron_lbaas/v2/handler_listener.py
@@ -83,13 +83,13 @@ class ListenerHandler(handler_base_v2.HandlerBaseV2):
                                                         axapi_args=server_args)
 
         try:
-            pool_name = self._pool_name(context, listener.default_pool)
+            pool_name = self._pool_name(context, pool_id=listener.default_pool_id)
         except Exception:
             pool_name = None
         persistence = handler_persist.PersistHandler(
             c, context, listener.default_pool)
         vport_meta = self.meta(listener, 'port', {})
-        a10_common._set_auto_parameter(vport_meta, self.a10_driver.device_info)
+        a10_common._set_auto_parameter(vport_meta, self.a10_driver.config)
         vport_args = {'port': vport_meta}
 
         try:

--- a/a10_neutron_lbaas/v2/handler_pool.py
+++ b/a10_neutron_lbaas/v2/handler_pool.py
@@ -37,6 +37,8 @@ class PoolHandler(handler_base_v2.HandlerBaseV2):
             axapi_args=args)
 
         # session persistence might need a vport update
+        import pdb
+        pdb.set_trace()
         if pool.listener:
             self.a10_driver.listener._update(c, context, pool.listener)
 

--- a/a10_neutron_lbaas/v2/handler_pool.py
+++ b/a10_neutron_lbaas/v2/handler_pool.py
@@ -37,9 +37,8 @@ class PoolHandler(handler_base_v2.HandlerBaseV2):
             axapi_args=args)
 
         # session persistence might need a vport update
-        import pdb
-        pdb.set_trace()
         if pool.listener:
+            pool.listener.default_pool_id = pool.listener.default_pool_id or pool.id
             self.a10_driver.listener._update(c, context, pool.listener)
 
     def _create(self, c, context, pool):

--- a/a10_neutron_lbaas/version.py
+++ b/a10_neutron_lbaas/version.py
@@ -1,1 +1,1 @@
-VERSION = "1.3.4"
+VERSION = "1.3.6"

--- a/tests/unit/v2/test_base.py
+++ b/tests/unit/v2/test_base.py
@@ -41,7 +41,8 @@ class FakeListener(FakeModel):
         self.protocol = protocol
         self.protocol_port = port
         self.admin_state_up = admin_state_up
-        self.default_pool = pool
+        self.default_pool = pool or FakePool('HTTP', 'ROUND_ROBIN', None)
+        self.default_pool_id = self.default_pool.id
         self.loadbalancer = loadbalancer
         self.default_tls_container_id = container_id
         self.sni_containers = containers


### PR DESCRIPTION
the _meta call accepts either a pool id or the pool (positionally).  We were passing in a pool where the ID should have been.  Additionally, we ensure that the default_pool_id property is appropriately set.

Version uptick to 1.3.6, fixed issue introduced in autonat that caused serious problems.