### PR TITLE
Set virtual server vrid based on default_virtual_server_vrid from device configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ Open `/etc/neutron/neutron_lbaas.conf` in your preferred text editor.
 In the list of `service_provider` settings, ensure there is only a single entry for LOADBALANCERV2 (you can comment out existing entries) enabled:
 `service_provider = LOADBALANCERV2:A10Networks:neutron_lbaas.drivers.a10networks.driver_v2.ThunderDriver:default`
 
+##### Device configuration
+
 After installation, you will need to provide configuration for the driver so the driver is aware of the appliances you have configured.  The configuration is a standard JSON structure stored in `/etc/a10/config.py`.  Below is a sample to show options and formatting:
 ```python
 devices = {
@@ -69,6 +71,7 @@ devices = {
         "username": "admin",
         "password": "a10",
         "status": True,
+        "default_virtual_server_vrid": 1,
         "autosnat": False,
         "api_version": "3.0",
         "v_method": "ADP",

--- a/a10_neutron_lbaas/a10_common.py
+++ b/a10_neutron_lbaas/a10_common.py
@@ -32,3 +32,10 @@ def _set_auto_parameter(vport, device_info):
     if vport_key is not None:
         cfg_value = device_info.get("autosnat", False)
         vport[vport_key] = vport_transform(cfg_value)
+
+
+def _set_vrid_parameter(virtual_server, device_info):
+    vrid = device_info.get("default_virtual_server_vrid", None)
+
+    if vrid is not None:
+        virtual_server['vrid'] = vrid

--- a/a10_neutron_lbaas/v1/handler_vip.py
+++ b/a10_neutron_lbaas/v1/handler_vip.py
@@ -61,8 +61,10 @@ class VipHandler(handler_base_v1.HandlerBaseV1):
 
             vport_list = [{}]
             try:
+                vip_meta = self.meta(vip, 'virtual_server', {})
+                a10_common._set_vrid_parameter(vip_meta, c.device_cfg)
                 vip_args = {
-                    'virtual_server': self.meta(vip, 'virtual_server', {})
+                    'virtual_server': vip_meta
                 }
                 vport_list = vip_args['virtual_server'].pop('vport_list', [{}])
                 c.client.slb.virtual_server.create(

--- a/a10_neutron_lbaas/v2/handler_lb.py
+++ b/a10_neutron_lbaas/v2/handler_lb.py
@@ -14,6 +14,8 @@
 
 import logging
 
+from a10_neutron_lbaas import a10_common
+
 import acos_client.errors as acos_errors
 import handler_base_v2
 import v2_context as a10
@@ -29,8 +31,10 @@ class LoadbalancerHandler(handler_base_v2.HandlerBaseV2):
             status = c.client.slb.DOWN
 
         try:
+            vip_meta = self.meta(lb, 'virtual_server', {})
+            a10_common._set_vrid_parameter(vip_meta, c.device_cfg)
             vip_args = {
-                'virtual_server': self.meta(lb, 'virtual_server', {})
+                'virtual_server': vip_meta
             }
             set_method(
                 self._meta_name(lb),

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "a10-neutron-lbaas",
-    version = "1.3.4",
+    version = "1.3.6",
     packages = find_packages(),
 
     author = "A10 Networks",

--- a/tests/unit/v2/test_handler_lb.py
+++ b/tests/unit/v2/test_handler_lb.py
@@ -12,6 +12,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+import mock
 import test_base
 
 import a10_neutron_lbaas.a10_exceptions as a10_ex
@@ -27,6 +28,51 @@ class TestLB(test_base.UnitTestBase):
         self.assertTrue('fake-lb-id-001' in s)
         self.assertTrue('5.5.5.5' in s)
         self.assertTrue('UP' in s)
+
+    def test_create_default_vrid_none_v21(self):
+        self._test_create_default_vrid("2.1", None)
+
+    def test_create_default_vrid_set_v21(self):
+        self._test_create_default_vrid("2.1", 7)
+
+    def test_create_default_vrid_none_v30(self):
+        self._test_create_default_vrid("3.0", None)
+
+    def test_create_default_vrid_set_v30(self):
+        self._test_create_default_vrid("3.0", 7)
+
+    def _test_create_default_vrid(self, api_ver=None, default_vrid=None):
+
+        """
+        Due to how the config is pulled in, we override the config
+        for all of the devices.
+        """
+
+        for k, v in self.a.config.devices.items():
+            v['api_version'] = api_ver
+            v['default_virtual_server_vrid'] = default_vrid
+
+        lb = test_base.FakeLoadBalancer()
+        self.a.lb.create(None, lb)
+
+        create = self.a.last_client.slb.virtual_server.create
+        create.assert_has_calls([mock.ANY])
+        calls = create.call_args_list
+
+        if default_vrid is not None:
+            foundVrid = any(
+                x.get('axapi_args', {}).get('virtual_server', {}).get('vrid', {}) is default_vrid
+                for (_, x) in calls)
+            self.assertTrue(
+                foundVrid,
+                'Expected to find vrid {0} in {1}'.format(default_vrid, str(calls)))
+        if default_vrid is None:
+            foundVrid = any(
+                'vrid' in x.get('axapi_args', {}).get('virtual_server', {})
+                for (_, x) in calls)
+            self.assertFalse(
+                foundVrid,
+                'Expected to find no vrid in {0}'.format(str(calls)))
 
     # def test_create_with_listeners(self):
     #     pool = test_base.FakePool('HTTP', 'ROUND_ROBIN', None)

--- a/tox.ini
+++ b/tox.ini
@@ -24,6 +24,7 @@ commands =
 
 [flake8]
 #ignore = E122,E125,E126,E128,E129,E251,E265,E713,F402,F811,F812,H104,H237,H302,H304,H305,H307,H401,H402,H404,H405,H904
+ignore = H404,H405
 show-source = true
 exclude = .venv,.git,.tox
 max-line-length = 100


### PR DESCRIPTION
Tests for setting vrid from the default_virtual_server_vrid when creting virtual servers

Ignore strange tox rules for multiline comments

Set virtual server vrid based on default_virtual_server_vrid from device configuration.

For #90