### PR TITLE
2.x IPINIPFIX

### DIFF
--- a/a10_neutron_lbaas/a10_common.py
+++ b/a10_neutron_lbaas/a10_common.py
@@ -42,16 +42,15 @@ def _set_auto_parameter(vport, device_info):
     auto_tuple = auto_dictionary.get(api_ver, None)
 
     if auto_tuple:
-        vport_key = auto_tuple[0]
-        vport_transform = auto_tuple[1]
+        (vport_key, vport_transform) = auto_tuple
 
-        cfg_value = device_info.get("autosnat", None)
-        if cfg_value is not None:
-            vport[vport_key] = vport_transform(cfg_value)
+    if vport_key is not None:
+        cfg_value = device_info.get("autosnat", False) or False
+        vport[vport_key] = vport_transform(cfg_value)
 
 
 def _set_vrid_parameter(virtual_server, device_info):
-    vrid = device_info.get("default_virtual_server_vrid", None)
+    vrid = device_info.get("default_virtual_server_vrid")
 
     if vrid is not None:
         virtual_server['vrid'] = vrid
@@ -66,11 +65,11 @@ def _set_ipinip_parameter(vport, device_info):
     transform = lambda x: x
 
     if ipinip_tuple:
-        key = ipinip_tuple[0]
-        transform = ipinip_tuple[1]
+        (key, transform) = ipinip_tuple
 
-    if key is not None:
-        ipinip = device_info.get(config_key, False)
+    ipinip = device_info.get(config_key, False) or False
+
+    if key is not None and ipinip:
         vport[key] = transform(ipinip)
 
 

--- a/a10_neutron_lbaas/a10_common.py
+++ b/a10_neutron_lbaas/a10_common.py
@@ -18,6 +18,11 @@ auto_dictionary = {
     "3.0": ("auto", lambda x: int(x))
 }
 
+ipinip_dictionary = {
+    "2.1": ("ip_in_ip", lambda x: int(x)),
+    "3.0": ("ipinip", lambda x: int(x))
+}
+
 
 vport_dictionary = {
     "2.1": "vport",
@@ -53,10 +58,20 @@ def _set_vrid_parameter(virtual_server, device_info):
 
 
 def _set_ipinip_parameter(vport, device_info):
-    key = "ipinip"
+    config_key = "ipinip"
+    api_ver = device_info.get("api_version", None)
+    ipinip_tuple = ipinip_dictionary.get(api_ver, None)
+    key = None
     ipinip = device_info.get(key, False)
-    if ipinip:
-        vport[key] = int(ipinip)
+
+    transform = lambda x: x
+    if ipinip_tuple:
+        key = ipinip_tuple[0]
+        transform = ipinip_tuple[1]
+
+    if key is not None:
+        cfg_value = device_info.get(config_key, False)
+        vport[key] = transform(cfg_value)
 
 
 def _vport(vport_meta, device_info):

--- a/a10_neutron_lbaas/a10_common.py
+++ b/a10_neutron_lbaas/a10_common.py
@@ -62,16 +62,16 @@ def _set_ipinip_parameter(vport, device_info):
     api_ver = device_info.get("api_version", None)
     ipinip_tuple = ipinip_dictionary.get(api_ver, None)
     key = None
-    ipinip = device_info.get(key, False)
 
     transform = lambda x: x
+
     if ipinip_tuple:
         key = ipinip_tuple[0]
         transform = ipinip_tuple[1]
 
     if key is not None:
-        cfg_value = device_info.get(config_key, False)
-        vport[key] = transform(cfg_value)
+        ipinip = device_info.get(config_key, False)
+        vport[key] = transform(ipinip)
 
 
 def _vport(vport_meta, device_info):

--- a/a10_neutron_lbaas/tests/unit/test_base.py
+++ b/a10_neutron_lbaas/tests/unit/test_base.py
@@ -21,6 +21,11 @@ import a10_neutron_lbaas.a10_openstack_lb as a10_os
 import a10_neutron_lbaas.plumbing_hooks as hooks
 
 
+def assertIn(expected, actual):
+    if expected not in actual:
+        raise Exception("Expected to find {0} in {1}".format(expected, actual))
+
+
 def _build_openstack_context():
     admin_context = {
         "tenant_id": "admin"
@@ -69,6 +74,11 @@ class FakeA10OpenstackLBV2(a10_os.A10OpenstackLBV2):
 
 
 class UnitTestBase(unittest.TestCase):
+    def __init__(self, *args):
+        super(UnitTestBase, self).__init__(*args)
+        if not hasattr(self, "assertIn"):
+            setattr(self, "assertIn", assertIn)
+
     def _build_openstack_context(self):
         return _build_openstack_context()
 

--- a/a10_neutron_lbaas/tests/unit/v2/test_handler_listener.py
+++ b/a10_neutron_lbaas/tests/unit/v2/test_handler_listener.py
@@ -166,10 +166,10 @@ class TestListeners(test_base.UnitTestBase):
 
         for k, v in self.a.config.devices.items():
             v['ipinip'] = ip_in_ip
+            v['api_version'] = api_ver
 
         if expected_tuple is not None:
-            key = expected_tuple[0]
-            transform = expected_tuple[1]
+            key, transform = expected_tuple
         else:
             key = None
             transform = None

--- a/a10_neutron_lbaas/tests/unit/v2/test_handler_listener.py
+++ b/a10_neutron_lbaas/tests/unit/v2/test_handler_listener.py
@@ -159,9 +159,24 @@ class TestListeners(test_base.UnitTestBase):
             if auto_expected is not None:
                 self.assertTrue(auto_expected in s)
 
-    def _test_create_ipinip(self, ip_in_ip=False):
+    def _test_create_ipinip(self, api_ver="3.0", ip_in_ip=False):
+        ipinip_expected = None
+        expected_tuple = a10_common.ipinip_dictionary.get(api_ver)
+        saw_exception = False
+
         for k, v in self.a.config.devices.items():
             v['ipinip'] = ip_in_ip
+
+        if expected_tuple is not None:
+            key = expected_tuple[0]
+            transform = expected_tuple[1]
+        else:
+            key = None
+            transform = None
+
+        if ip_in_ip and key and transform:
+            ipinip_format = "'{0}': {1}"
+            ipinip_expected = ipinip_format.format(key, transform(ip_in_ip))
 
         p = 'TCP'
         lb = test_base.FakeLoadBalancer()
@@ -171,14 +186,24 @@ class TestListeners(test_base.UnitTestBase):
 
         self.a.listener.create(None, m)
         self.print_mocks()
-        s = str(self.a.last_client.mock_calls)
-        self.assertEqual(ip_in_ip, "ipinip" in s)
 
-    def test_create_ip_in_ip_positive(self):
-        self._test_create_ipinip(True)
+        if not saw_exception:
+            s = str(self.a.last_client.mock_calls)
+            self.assertIn("vport.create", s)
+            if ipinip_expected is not None:
+                self.assertIn(ipinip_expected, s)
 
-    def test_create_ip_in_ip_negative(self):
-        self._test_create_ipinip()
+    def test_create_ip_in_ip_positive_v21(self):
+        self._test_create_ipinip(api_ver="2.1", ip_in_ip=True)
+
+    def test_create_ip_in_ip_negative_v21(self):
+        self._test_create_ipinip(api_ver="2.1")
+
+    def test_create_ip_in_ip_positive_v30(self):
+        self._test_create_ipinip(ip_in_ip=True)
+
+    def test_create_ip_in_ip_negative_v30(self):
+        self._test_create_ipinip("3.0")
 
     def test_update_no_lb(self):
         m = test_base.FakeListener('TCP', 2222, pool=mock.MagicMock(),


### PR DESCRIPTION
It was discovered that v2.x appliances don't accept the same parameter as v4 devices, similar to `auto`/`source_nat_auto`.