### PR TITLE
tox coverage environment

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,7 @@
+[run]
+branch = True
+include = *a10_neutron_lbaas*
+
+[html]
+directory = htmlcov
+

--- a/tox.ini
+++ b/tox.ini
@@ -28,3 +28,11 @@ ignore = H404,H405
 show-source = true
 exclude = .venv,.git,.tox
 max-line-length = 100
+
+[testenv:coverage]
+whitelist_externals = find
+commands = find {toxinidir} -name "*.pyc" -type f -delete
+           coverage erase
+           nosetests --with-coverage --cover-inclusive --cover-html --cover-html-dir={toxinidir}/htmlcov
+deps = coverage
+       {[testenv]deps}


### PR DESCRIPTION
Run coverage with `tox -e coverage`. Html report will be put in `htmlcov/`