### PR TITLE
Scheduling Refactor and Database Appliance Scheduling

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ Open `/etc/neutron/neutron_lbaas.conf` in your preferred text editor.
 In the list of `service_provider` settings, ensure there is only a single entry for LOADBALANCERV2 (you can comment out existing entries) enabled:
 `service_provider = LOADBALANCERV2:A10Networks:neutron_lbaas.drivers.a10networks.driver_v2.ThunderDriver:default`
 
+##### Extension configuration
+Open `/etc/neutron/neutron.conf` in your preferred text editor.
+Under the `service_plugins` setting, ensure `a10_neutron_lbaas.neutron_ext.services.a10_appliance.plugin.A10AppliancePlugin` is listed. The `service_plugins` are separated by `,`s.
+
+Under the `api_extensions_path` setting, ensure the path to `a10_neutron_lbaas.neutron_ext.extensions` is listed. The `api_extensions_path`s are separated by `:`s. You can find the path of the installed extension by running `python -c "import os; import a10_neutron_lbaas.neutron_ext.extensions as m; print(os.path.dirname(os.path.abspath(m.__file__)))"`.
+
 ##### Device configuration
 
 After installation, you will need to provide configuration for the driver so the driver is aware of the appliances you have configured.  The configuration is a standard JSON structure stored in `/etc/a10/config.py`.  Below is a sample to show options and formatting:

--- a/a10_neutron_lbaas/a10_openstack_lb.py
+++ b/a10_neutron_lbaas/a10_openstack_lb.py
@@ -18,7 +18,9 @@ import a10_config
 import acos_client
 import db.operations as operations
 import inventory
+import network_hooks
 import plumbing_hooks as hooks
+import scheduling_hooks
 import v1.handler_hm
 import v1.handler_member
 import v1.handler_pool
@@ -44,11 +46,14 @@ LOG = logging.getLogger(__name__)
 class A10OpenstackLBBase(object):
 
     def __init__(self, openstack_driver,
-                 plumbing_hooks_class=hooks.PlumbingHooks,
+                 plumbing_hooks_class=None,
                  neutron_hooks_module=None,
                  barbican_client=None,
                  db_operations_class=operations.Operations,
-                 inventory_class=inventory.InventoryBase):
+                 inventory_class=inventory.InventoryBase,
+                 scheduling_hooks_class=None,
+                 network_hooks_class=None
+                 ):
         self.openstack_driver = openstack_driver
         self.config = a10_config.A10Config()
         self.neutron = neutron_hooks_module
@@ -62,10 +67,30 @@ class A10OpenstackLBBase(object):
         if self.config.verify_appliances:
             self._verify_appliances()
 
-        self.hooks = plumbing_hooks_class(self)
+        if plumbing_hooks_class is not None:
+            plumbing_hooks = plumbing_hooks_class(self)
+            self._plumbing_hooks = plumbing_hooks
+        else:
+            # _plumbing_hooks is used by the migrations to reach the old behaviour
+            self._plumbing_hooks = hooks.PlumbingHooks(self)
 
-    def _select_a10_device(self, tenant_id):
-        return self.hooks.select_device(tenant_id)
+        if scheduling_hooks_class is None:
+            scheduling_hooks_class = (
+                scheduling_hooks.existing_device_per_tenant
+                if plumbing_hooks_class is None else
+                scheduling_hooks.plumbing_hooks_device_per_tenant(plumbing_hooks)
+            )
+        self.scheduling_hooks = scheduling_hooks_class(self)
+
+        if network_hooks_class is None:
+            network_hooks_class = (
+                network_hooks.DefaultNetworkHooks
+                if plumbing_hooks_class is None else
+                network_hooks.plumbing_network_hooks(plumbing_hooks)
+            )
+        self.network_hooks = network_hooks_class(self)
+
+        self.hooks = self.network_hooks
 
     def _get_a10_client(self, device_info):
         d = device_info

--- a/a10_neutron_lbaas/db/migration/alembic_migrations/versions/2c45cb7e1c1d_a10_appliances_db_table.py
+++ b/a10_neutron_lbaas/db/migration/alembic_migrations/versions/2c45cb7e1c1d_a10_appliances_db_table.py
@@ -44,7 +44,9 @@ def upgrade():
         sa.Column('host', sa.String(255), nullable=False),
         sa.Column('api_version', sa.String(12), nullable=False),
         sa.Column('username', sa.String(255), nullable=False),
-        sa.Column('password', sa.String(255), nullable=False)
+        sa.Column('password', sa.String(255), nullable=False),
+        sa.Column('protocol', sa.String(255), nullable=False),
+        sa.Column('port', sa.Integer, nullable=False)
     )
 
 

--- a/a10_neutron_lbaas/db/migration/step.py
+++ b/a10_neutron_lbaas/db/migration/step.py
@@ -74,7 +74,7 @@ def initialize_a10_slb_v1(conn, provider, a10):
         column('a10_appliance_id'))
     for vip in vips:
         id = str(uuid.uuid4())
-        device = a10.hooks.select_device(vip['tenant_id'])
+        device = a10._plumbing_hooks.select_device(vip['tenant_id'])
         appliance = appliance_lookup[device['key']]
         insert_slb = a10_slb.insert().\
             values(id=id, type=a10_slb_v1.name, a10_appliance_id=appliance)
@@ -109,7 +109,7 @@ def initialize_a10_slb_v2(conn, provider, a10):
         column('a10_appliance_id'))
     for lb in lbs:
         id = str(uuid.uuid4())
-        device = a10.hooks.select_device(lb['tenant_id'])
+        device = a10._plumbing_hooks.select_device(lb['tenant_id'])
         appliance = appliance_lookup[device['key']]
         insert_slb = a10_slb.insert().\
             values(id=id, type=a10_slb_v2.name, a10_appliance_id=appliance)

--- a/a10_neutron_lbaas/db/models.py
+++ b/a10_neutron_lbaas/db/models.py
@@ -70,7 +70,10 @@ class A10ApplianceConfigured(A10ApplianceSLB):
     device_key = sa.Column(sa.String(255), nullable=False)
 
     def device(self, context):
-        return context.a10_driver.config.devices[self.device_key]
+        config_device = context.a10_driver.config.devices[self.device_key]
+        device = config_device.copy()
+        device['appliance'] = self
+        return device
 
     __mapper_args__ = {
         'polymorphic_identity': __tablename__
@@ -96,7 +99,13 @@ class A10ApplianceDB(A10ApplianceSLB):
     password = sa.Column(sa.String(255), nullable=False)
 
     def device(self, context):
-        return context.a10_driver.config.devices[self.device_key]
+        return {
+            'appliance': self,
+            'host': self.host,
+            'api_version': self.api_version,
+            'username': self.username,
+            'password': self.password
+        }
 
     __mapper_args__ = {
         'polymorphic_identity': __tablename__

--- a/a10_neutron_lbaas/db/models.py
+++ b/a10_neutron_lbaas/db/models.py
@@ -97,15 +97,23 @@ class A10ApplianceDB(A10ApplianceSLB):
     api_version = sa.Column(sa.String(12), nullable=False)
     username = sa.Column(sa.String(255), nullable=False)
     password = sa.Column(sa.String(255), nullable=False)
+    protocol = sa.Column(sa.String(255), nullable=False)
+    port = sa.Column(sa.Integer, nullable=False)
 
     def device(self, context):
-        return {
+        # TODO(aritrary config): When we store all the options
+        # we shouldn't neet to get defaults from the config
+        config = context.a10_driver.config
+        device = {
             'appliance': self,
             'host': self.host,
             'api_version': self.api_version,
             'username': self.username,
-            'password': self.password
+            'password': self.password,
+            'protocol': self.protocol,
+            'port': self.port
         }
+        return config.device_defaults(device)
 
     __mapper_args__ = {
         'polymorphic_identity': __tablename__

--- a/a10_neutron_lbaas/db/operations.py
+++ b/a10_neutron_lbaas/db/operations.py
@@ -12,6 +12,9 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.from neutron.db import model_base
 
+from sqlalchemy import or_
+from sqlalchemy.orm import with_polymorphic
+
 import models
 
 
@@ -49,6 +52,18 @@ class Operations(object):
     def get_tenant_appliance(self, tenant_id):
         return self.session.query(models.A10TenantAppliance).\
             filter_by(tenant_id=tenant_id).first()
+
+    def get_shared_appliances(self, tenant_id):
+        """Get appliances that are shared with (available for the tenant to use)"""
+
+        any_appliance = with_polymorphic(models.A10ApplianceSLB,
+                                         [models.A10ApplianceConfigured, models.A10ApplianceDB])
+        not_null_ = lambda x: x != None  # noqa
+        return list(self.session.query(any_appliance).filter(
+            or_(
+                not_null_(any_appliance.A10ApplianceConfigured.id),
+                any_appliance.A10ApplianceDB.tenant_id == tenant_id
+            )))
 
     def add(self, obj):
         # print 'add({0})'.format(repr(obj))

--- a/a10_neutron_lbaas/inventory.py
+++ b/a10_neutron_lbaas/inventory.py
@@ -30,20 +30,23 @@ class InventoryBase(object):
 
         return self.db_operations.get_shared_appliances(self.a10_context.tenant_id)
 
-    def device_appliance(self, device):
-        appliance = device.get('appliance')
+    def device_appliance(self, device_config):
+        appliance = device_config.get('appliance')
 
         if appliance is None:
             # TODO(aritrary config): Support for arbitrary options
+            device = self.a10_driver.config.device_defaults(device_config)
             appliance = models.default(
                 models.A10ApplianceDB,
                 name=device.get('name', None),
                 description=device.get('description', None),
                 tenant_id=self.a10_context.tenant_id,
                 host=device['host'],
-                api_version=device.get('api_version', '2.1'),
+                api_version=device['api_version'],
                 username=device['username'],
-                password=device['password'])
+                password=device['password'],
+                protocol=device['protocol'],
+                port=device['port'])
             self.db_operations.add(appliance)
 
         return appliance

--- a/a10_neutron_lbaas/inventory.py
+++ b/a10_neutron_lbaas/inventory.py
@@ -13,6 +13,7 @@
 #    under the License.from neutron.db import model_base
 
 import a10_neutron_lbaas.db.models as models
+import a10_neutron_lbaas.scheduling_hooks as scheduling_hooks
 
 
 class InventoryBase(object):
@@ -21,37 +22,52 @@ class InventoryBase(object):
         self.a10_driver = self.a10_context.a10_driver
         self.db_operations = self.a10_context.db_operations
 
-    def tenant_appliance(self):
-        """Chooses the appliance a tenant is already on, or assigns it"""
-        tenant_id = self.a10_context.tenant_id
-        tenant = self.db_operations.get_tenant_appliance(tenant_id)
-        if tenant is None:
-            # Assign this tenant to an appliance
-            appliance = self.select_tenant_appliance()
-            tenant = models.default(
-                models.A10TenantAppliance,
-                tenant_id=tenant_id,
-                a10_appliance=appliance)
-            self.db_operations.add(tenant)
+    def get_appliances(self):
+        """Get appliances available to this tenant"""
+        # Populate all the config devices
+        for device_key in self.a10_driver.config.devices:
+            self.db_operations.summon_appliance_configured(device_key)
 
-        return tenant.a10_appliance
+        return self.db_operations.get_shared_appliances(self.a10_context.tenant_id)
 
-    def select_tenant_appliance(self):
-        """Chooses an appliance affinity for a new tenant"""
-        device = self.a10_driver._select_a10_device(self.a10_context.tenant_id)
-        appliance = self.db_operations.summon_appliance_configured(device['key'])
+    def device_appliance(self, device):
+        appliance = device.get('appliance')
+
+        if appliance is None:
+            # TODO(aritrary config): Support for arbitrary options
+            appliance = models.default(
+                models.A10ApplianceDB,
+                name=device.get('name', None),
+                description=device.get('description', None),
+                tenant_id=self.a10_context.tenant_id,
+                host=device['host'],
+                api_version=device.get('api_version', '2.1'),
+                username=device['username'],
+                password=device['password'])
+            self.db_operations.add(appliance)
+
         return appliance
 
-    def select_appliance(self, openstack_lbaas_obj):
+    def select_appliance(self, openstack_lbaas_obj, scheduling_hooks=None):
         """Chooses an appliance for a new loadbalancer
 
-        When we add scheduling hooks, this will delegate the choice to the scheduler.
-        For now, it always chooses based on tenant affinity.
+        Delegates the choice to scheduling hooks.
         """
-        return self.tenant_appliance()
+        scheduling_hooks = scheduling_hooks or self.a10_driver.scheduling_hooks
+
+        appliances = self.get_appliances()
+        device_configs = [a.device(self.a10_context) for a in appliances]
+
+        selected_devices = scheduling_hooks.select_devices(self.a10_context, device_configs)
+        selected_device = next(selected_devices.__iter__())
+
+        appliance = self.device_appliance(selected_device)
+
+        return appliance
 
     def find(self, openstack_lbaas_obj):
         """Find or select the appliance the openstack_lbaas_obj lives on"""
 
         # The default, safe implementation puts all of a tenant's objects on the same appliance
-        return self.tenant_appliance()
+        per_tenant_scheduler = scheduling_hooks.DevicePerTenant(self.a10_driver.scheduling_hooks)
+        return self.select_appliance(openstack_lbaas_obj, per_tenant_scheduler)

--- a/a10_neutron_lbaas/network_hooks.py
+++ b/a10_neutron_lbaas/network_hooks.py
@@ -1,0 +1,120 @@
+# Copyright 2015,  A10 Networks
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.from neutron.db import model_base
+
+import abc
+import six
+
+
+@six.add_metaclass(abc.ABCMeta)
+class NetworkHooks(object):
+    """Interface for network hooks"""
+
+    @abc.abstractmethod
+    def partition_create(self, client, a10_context, context, partition_name):
+        pass
+
+    @abc.abstractmethod
+    def partition_delete(self, client, a10_context, context, partition_name):
+        pass
+
+    @abc.abstractmethod
+    def after_member_create(self, a10_context, context, member):
+        pass
+
+    @abc.abstractmethod
+    def after_member_update(self, a10_context, context, member):
+        pass
+
+    @abc.abstractmethod
+    def after_member_delete(self, a10_context, context, member):
+        pass
+
+    @abc.abstractmethod
+    def after_vip_create(self, a10_context, context, vip):
+        pass
+
+    @abc.abstractmethod
+    def after_vip_update(self, a10_context, context, vip):
+        pass
+
+    @abc.abstractmethod
+    def after_vip_delete(self, a10_context, context, vip):
+        pass
+
+
+class DefaultNetworkHooksMixin(NetworkHooks):
+
+    def partition_create(self, client, a10_context, context, partition_name):
+        client.system.partition.create(partition_name)
+
+    def partition_delete(self, client, a10_context, context, partition_name):
+        client.system.partition.delete(partition_name)
+
+    def after_member_create(self, a10_context, context, member):
+        pass
+
+    def after_member_update(self, a10_context, context, member):
+        pass
+
+    def after_member_delete(self, a10_context, context, member):
+        pass
+
+    def after_vip_create(self, a10_context, context, vip):
+        pass
+
+    def after_vip_update(self, a10_context, context, vip):
+        pass
+
+    def after_vip_delete(self, a10_context, context, vip):
+        pass
+
+
+class DefaultNetworkHooks(DefaultNetworkHooksMixin):
+
+    def __init__(self, a10_driver):
+        pass
+
+
+class PlumbingNetworkHooks(NetworkHooks):
+
+    def __init__(self, plumbing_hooks):
+        self.plumbing_hooks = plumbing_hooks
+
+    def partition_create(self, client, a10_context, context, partition_name):
+        self.plumbing_hooks.partition_create(client, context, partition_name)
+
+    def partition_delete(self, client, a10_context, context, partition_name):
+        self.plumbing_hooks.partition_delete(client, context, partition_name)
+
+    def after_member_create(self, a10_context, context, member):
+        self.plumbing_hooks.after_member_create(a10_context, context, member)
+
+    def after_member_update(self, a10_context, context, member):
+        self.plumbing_hooks.after_member_update(a10_context, context, member)
+
+    def after_member_delete(self, a10_context, context, member):
+        self.plumbing_hooks.after_member_delete(a10_context, context, member)
+
+    def after_vip_create(self, a10_context, context, vip):
+        self.plumbing_hooks.after_vip_create(a10_context, context, vip)
+
+    def after_vip_update(self, a10_context, context, vip):
+        self.plumbing_hooks.after_vip_update(a10_context, context, vip)
+
+    def after_vip_delete(self, a10_context, context, vip):
+        self.plumbing_hooks.after_vip_delete(a10_context, context, vip)
+
+
+def plumbing_network_hooks(plumbing_hooks):
+    return lambda a10_driver: PlumbingNetworkHooks(plumbing_hooks)

--- a/a10_neutron_lbaas/neutron_ext/common/resources.py
+++ b/a10_neutron_lbaas/neutron_ext/common/resources.py
@@ -1,0 +1,37 @@
+# Copyright 2016,  A10 Networks
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import collections
+
+from neutron.api.v2 import attributes
+
+import six
+
+
+def remove_attributes_not_specified(resource):
+    return dict((k, v) for k, v in resource.items() if v != attributes.ATTR_NOT_SPECIFIED)
+
+
+def apply_template(template, *args, **kw):
+    """Applies every callable in any Mapping or Iterable"""
+
+    if six.callable(template):
+        return template(*args, **kw)
+    if isinstance(template, six.string_types):
+        return template
+    if isinstance(template, collections.Mapping):
+        return template.__class__((k, apply_template(v, *args, **kw)) for k, v in template.items())
+    if isinstance(template, collections.Iterable):
+        return template.__class__(apply_template(v, *args, **kw) for v in template)
+    return template

--- a/a10_neutron_lbaas/neutron_ext/db/a10_appliance.py
+++ b/a10_neutron_lbaas/neutron_ext/db/a10_appliance.py
@@ -101,9 +101,9 @@ class A10ApplianceDbMixin(common_db_mixin.CommonDbMixin, a10Appliance.A10Applian
             # Remove tenant affinities
             # The tenant partitions on the appliance should have been removed
             # when the last object was deleted
-            context.session.query(models.A10TenantAppliance).\
-                filter_by(a10_appliance_id=appliance.id).\
-                delete()
+            unused_affinities = context.session.query(models.A10TenantAppliance).\
+                filter_by(a10_appliance_id=appliance.id)
+            models.delete_all(context.session, unused_affinities)
             context.session.delete(appliance)
 
     def get_a10_appliance(self, context, a10_appliance_id, fields=None):

--- a/a10_neutron_lbaas/neutron_ext/extensions/a10Appliance.py
+++ b/a10_neutron_lbaas/neutron_ext/extensions/a10Appliance.py
@@ -14,6 +14,7 @@
 
 import a10_neutron_lbaas.localization as localization
 import a10_neutron_lbaas.neutron_ext.common.constants as constants
+from a10_neutron_lbaas.neutron_ext.common import resources
 import a10_neutron_lbaas_client.resources.a10_appliance as a10_appliance
 
 import abc
@@ -28,6 +29,8 @@ import six
 
 # Neutron is finicky. Sometimes _ is defined, sometimes it isn't
 localization.install()
+
+RESOURCE_ATTRIBUTE_MAP = resources.apply_template(a10_appliance.RESOURCE_ATTRIBUTE_MAP, attributes)
 
 
 class A10Appliance(extensions.ExtensionDescriptor):
@@ -56,9 +59,9 @@ class A10Appliance(extensions.ExtensionDescriptor):
     def get_resources(cls):
         """Returns external resources."""
         my_plurals = resource_helper.build_plural_mappings(
-            {}, a10_appliance.RESOURCE_ATTRIBUTE_MAP)
+            {}, RESOURCE_ATTRIBUTE_MAP)
         attributes.PLURALS.update(my_plurals)
-        attr_map = a10_appliance.RESOURCE_ATTRIBUTE_MAP
+        attr_map = RESOURCE_ATTRIBUTE_MAP
         resources = resource_helper.build_resource_info(my_plurals,
                                                         attr_map,
                                                         constants.A10_APPLIANCE)
@@ -68,11 +71,11 @@ class A10Appliance(extensions.ExtensionDescriptor):
     def update_attributes_map(self, attributes):
         super(A10Appliance, self).update_attributes_map(
             attributes,
-            extension_attrs_map=a10_appliance.RESOURCE_ATTRIBUTE_MAP)
+            extension_attrs_map=RESOURCE_ATTRIBUTE_MAP)
 
     def get_extended_resources(self, version):
         if version == "2.0":
-            return a10_appliance.RESOURCE_ATTRIBUTE_MAP
+            return RESOURCE_ATTRIBUTE_MAP
         else:
             return {}
 

--- a/a10_neutron_lbaas/plumbing_hooks.py
+++ b/a10_neutron_lbaas/plumbing_hooks.py
@@ -32,20 +32,20 @@ class PlumbingHooks(object):
     def partition_delete(self, client, context, partition_name):
         client.system.partition.delete(partition_name)
 
-    def after_member_create(self, client, context, member):
+    def after_member_create(self, a10_context, context, member):
         pass
 
-    def after_member_update(self, client, context, member):
+    def after_member_update(self, a10_context, context, member):
         pass
 
-    def after_member_delete(self, client, context, member):
+    def after_member_delete(self, a10_context, context, member):
         pass
 
-    def after_vip_create(self, client, context, vip):
+    def after_vip_create(self, a10_context, context, vip):
         pass
 
-    def after_vip_update(self, client, context, vip):
+    def after_vip_update(self, a10_context, context, vip):
         pass
 
-    def after_vip_delete(self, client, context, vip):
+    def after_vip_delete(self, a10_context, context, vip):
         pass

--- a/a10_neutron_lbaas/scheduling_hooks.py
+++ b/a10_neutron_lbaas/scheduling_hooks.py
@@ -1,0 +1,109 @@
+# Copyright 2015,  A10 Networks
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.from neutron.db import model_base
+
+import abc
+import six
+
+import acos_client
+
+import a10_neutron_lbaas.db.models as models
+
+
+@six.add_metaclass(abc.ABCMeta)
+class SchedulingHooks(object):
+    """Interface for scheduling hooks"""
+
+    @abc.abstractmethod
+    def select_devices(self, a10_context, device_list, **kwargs):
+        pass
+
+
+class DevicePerTenant(SchedulingHooks):
+
+    def __init__(self, underlying_scheduler):
+        self.underlying_scheduler = underlying_scheduler
+
+    def select_devices(self, a10_context, device_list, **kwargs):
+        """Chooses the appliance a tenant is already on, or assigns it"""
+        tenant_id = a10_context.tenant_id
+        db_operations = a10_context.db_operations
+        tenant = db_operations.get_tenant_appliance(tenant_id)
+        if tenant is None:
+            # Assign this tenant to an appliance
+            devices = self.underlying_scheduler.select_devices(a10_context, device_list)
+            device = next(devices.__iter__())
+
+            # We need an appliance to save the a10 tenant appliance
+            appliance = a10_context.inventory.device_appliance(device)
+
+            # The underlying_scheduler might have assigned the tenant to an appliance
+            tenant = db_operations.get_tenant_appliance(tenant_id)
+            if tenant is None:
+                tenant = models.default(
+                    models.A10TenantAppliance,
+                    tenant_id=tenant_id,
+                    a10_appliance=appliance)
+                db_operations.add(tenant)
+
+        device = tenant.a10_appliance.device(a10_context)
+
+        return [device]
+
+
+class ExistingDevice(SchedulingHooks):
+    """Uses an existing device. Prefers a device owned by the tenant"""
+
+    def select_devices(self, a10_context, device_list, **kwargs):
+        tenant_id = a10_context.tenant_id
+        tenant_devices = filter(
+            lambda x: getattr(x.get('appliance'), 'tenant_id', None) == tenant_id,
+            device_list)
+
+        for devices in [tenant_devices, device_list]:
+            if any(devices):
+                device_dict = dict([
+                    (getattr(x.get('appliance'), 'id', None) or 'key-' + x.get('key'), x)
+                    for x in devices])
+                appliance_hash = acos_client.Hash(device_dict.keys())
+                key = appliance_hash.get_server(tenant_id)
+                return [device_dict[key]]
+
+
+def existing_device_per_tenant(a10_driver):
+    existing_device = ExistingDevice()
+    device_per_tenant = DevicePerTenant(existing_device)
+    return device_per_tenant
+
+
+class PlumbingHooksDevice(SchedulingHooks):
+    """Uses only devices listed in the config file.
+    Asks plumbing hooks to select_device
+
+    Provided for backwards compatibility with systems that implemented custom plumbing hooks
+    """
+
+    def __init__(self, plumbing_hooks):
+        self.plumbing_hooks = plumbing_hooks
+
+    def select_devices(self, a10_context, device_list, **kwargs):
+        device = self.plumbing_hooks.select_device(a10_context.tenant_id)
+        return filter(lambda x: x.get('key', None) == device['key'], device_list)
+
+
+def plumbing_hooks_device_per_tenant(plumbing_hooks):
+    def f(a10_driver):
+        plumbing_hooks_scheduler = PlumbingHooksDevice(plumbing_hooks)
+        device_per_tenant = DevicePerTenant(plumbing_hooks_scheduler)
+        return device_per_tenant
+    return f

--- a/a10_neutron_lbaas/tests/db/migration/test_cli.py
+++ b/a10_neutron_lbaas/tests/db/migration/test_cli.py
@@ -215,7 +215,7 @@ class TestCLI(test_base.UnitTestBase):
             name='mock_a10',
             spec=a10_neutron_lbaas.A10OpenstackLBV1,
             config=mock_config,
-            hooks=mock_hooks)
+            _plumbing_hooks=mock_hooks)
         mock_driver = mock.MagicMock(
             name='mock_driver',
             a10=mock_a10)
@@ -271,7 +271,7 @@ class TestCLI(test_base.UnitTestBase):
             name='mock_a10',
             spec=a10_neutron_lbaas.A10OpenstackLBV2,
             config=mock_config,
-            hooks=mock_hooks)
+            _plumbing_hooks=mock_hooks)
         mock_driver = mock.MagicMock(
             name='mock_driver',
             a10=mock_a10)

--- a/a10_neutron_lbaas/tests/db/neutron_ext/db/test_a10_appliance.py
+++ b/a10_neutron_lbaas/tests/db/neutron_ext/db/test_a10_appliance.py
@@ -44,6 +44,18 @@ class TestA10ApplianceDbMixin(test_base.UnitTestBase):
             'password': 'fake-password'
         }
 
+    def fake_appliance_options(self):
+        return {
+            'protocol': 'http',
+            'port': 12345
+        }
+
+    def default_options(self):
+        return {
+            'protocol': 'https',
+            'port': 443
+        }
+
     def envelope(self, body):
         return {a10_appliance_resources.RESOURCE: body}
 
@@ -53,13 +65,38 @@ class TestA10ApplianceDbMixin(test_base.UnitTestBase):
         result = self.plugin.create_a10_appliance(context, self.envelope(appliance))
         context.session.commit()
         self.assertIsNot(result['id'], None)
-        expected = appliance.copy()
+        expected = self.default_options()
+        expected.update(appliance)
         expected.update(
             {
                 'id': result['id'],
                 'tenant_id': context.tenant_id
             })
         self.assertEqual(expected, result)
+
+    def test_create_a10_appliance_options(self):
+        appliance = self.fake_appliance()
+        appliance.update(self.fake_appliance_options())
+        context = self.context()
+        result = self.plugin.create_a10_appliance(context, self.envelope(appliance))
+        context.session.commit()
+        self.assertIsNot(result['id'], None)
+        expected = appliance.copy()
+        expected.update(
+            {
+                'id': result['id'],
+                'tenant_id': context.tenant_id,
+            })
+        self.assertEqual(expected, result)
+
+    def test_create_a10_appliance_default_port(self):
+        appliance = self.fake_appliance()
+        appliance['protocol'] = 'http'
+        context = self.context()
+        result = self.plugin.create_a10_appliance(context, self.envelope(appliance))
+        context.session.commit()
+        self.assertIsNot(result['id'], None)
+        self.assertEqual(80, result['port'])
 
     def test_get_a10_appliance(self):
         appliance = self.fake_appliance()

--- a/a10_neutron_lbaas/tests/db/test_a10_context.py
+++ b/a10_neutron_lbaas/tests/db/test_a10_context.py
@@ -1,0 +1,89 @@
+# Copyright 2015,  A10 Networks
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.from neutron.db import model_base
+
+import mock
+
+import a10_neutron_lbaas.tests.unit.test_a10_openstack_lb as test_a10_openstack_lb
+import a10_neutron_lbaas.tests.unit.unit_config as unit_config
+import test_base
+
+import a10_neutron_lbaas.a10_context as a10_context
+import a10_neutron_lbaas.db.models as models
+
+
+class TestA10Context(test_a10_openstack_lb.SetupA10OpenstackLBBase, test_base.UnitTestBase):
+
+    def setUp(self):
+        super(TestA10Context, self).setUp()
+
+        unit_config.setUp()
+
+        mock_driver = mock.MagicMock()
+        with mock.patch('acos_client.Client'):
+            a10_driver = self.a10_openstack_lb_class(mock_driver, **self.a10_openstack_lb_kws)
+
+        a10_driver._get_a10_client = lambda self: mock.MagicMock()
+        mock_handler = mock.MagicMock(openstack_driver=mock_driver, a10_driver=a10_driver)
+
+        session = self.open_session()
+        mock_openstack_context = mock.MagicMock(session=session)
+
+        mock_openstack_lbaas_obj = mock.MagicMock(tenant_id='fake-tenant-id')
+
+        self.a10_context = a10_context.A10Context(mock_handler,
+                                                  mock_openstack_context,
+                                                  mock_openstack_lbaas_obj)
+
+    def test_inventory_find(self):
+        """Test inventory and scheduling hooks in their almost-real environment"""
+
+        with self.a10_context:
+            appliance = self.a10_context.inventory.find(self.a10_context.openstack_lbaas_obj)
+
+        session = self.a10_context.db_operations.session
+        session.commit()
+        saved_appliance = session.query(models.A10ApplianceSLB).get(appliance.id)
+
+        self.assertEqual(appliance, saved_appliance)
+
+
+class TestA10ContextPlumbingHooks(test_a10_openstack_lb.SetupPlumbingHooks, TestA10Context):
+    pass
+
+
+class TestA10ContextV1(test_a10_openstack_lb.SetupA10OpenstackLBV1, TestA10Context):
+    pass
+
+
+class TestA10ContextV1PlumbingHooks(test_a10_openstack_lb.SetupA10OpenstackLBV1,
+                                    test_a10_openstack_lb.SetupPlumbingHooks,
+                                    TestA10Context):
+    pass
+
+
+class SetupA10ContextV2(test_a10_openstack_lb.SetupA10OpenstackLBV2):
+
+    def setUp(self):
+        super(SetupA10ContextV2, self).setUp()
+        self.a10_context.openstack_lbaas_obj.root_loadbalancer = mock.MagicMock(id='fake-lb-id')
+
+
+class TestA10ContextV2(SetupA10ContextV2, TestA10Context):
+    pass
+
+
+class TestA10ContextV2PlumbingHooks(SetupA10ContextV2,
+                                    test_a10_openstack_lb.SetupPlumbingHooks,
+                                    TestA10Context):
+    pass

--- a/a10_neutron_lbaas/tests/db/test_operations.py
+++ b/a10_neutron_lbaas/tests/db/test_operations.py
@@ -63,7 +63,9 @@ class TestOperations(test_base.UnitTestBase):
                                    host='fake-host',
                                    api_version='fake-version',
                                    username='fake-username',
-                                   password='fake-password')
+                                   password='fake-password',
+                                   protocol='fake-protocol',
+                                   port=1234)
         operations.add(appliance)
         shared = operations.get_shared_appliances('fake-tenant')
 
@@ -76,7 +78,9 @@ class TestOperations(test_base.UnitTestBase):
                                    host='fake-host',
                                    api_version='fake-version',
                                    username='fake-username',
-                                   password='fake-password')
+                                   password='fake-password',
+                                   protocol='fake-protocol',
+                                   port=1234)
         operations.add(appliance)
         shared = operations.get_shared_appliances('fake-tenant')
 

--- a/a10_neutron_lbaas/tests/db/test_operations.py
+++ b/a10_neutron_lbaas/tests/db/test_operations.py
@@ -16,6 +16,7 @@ import mock
 
 import test_base
 
+import a10_neutron_lbaas.db.models as models
 import a10_neutron_lbaas.db.operations as db_operations
 
 
@@ -47,3 +48,36 @@ class TestOperations(test_base.UnitTestBase):
         operations2.session.commit()
 
         self.assertNotEqual(appliance1.id, appliance2.id)
+
+    def test_get_shared_appliances_configured(self):
+        operations = self.operations()
+        appliance = operations.summon_appliance_configured('fake-device-key')
+        shared = operations.get_shared_appliances('fake-tenant')
+
+        self.assertEqual([appliance], shared)
+
+    def test_get_shared_appliances_db_same_tenant(self):
+        operations = self.operations()
+        appliance = models.default(models.A10ApplianceDB,
+                                   tenant_id='fake-tenant',
+                                   host='fake-host',
+                                   api_version='fake-version',
+                                   username='fake-username',
+                                   password='fake-password')
+        operations.add(appliance)
+        shared = operations.get_shared_appliances('fake-tenant')
+
+        self.assertEqual([appliance], shared)
+
+    def test_get_shared_appliances_db_other_tenant(self):
+        operations = self.operations()
+        appliance = models.default(models.A10ApplianceDB,
+                                   tenant_id='other-tenant',
+                                   host='fake-host',
+                                   api_version='fake-version',
+                                   username='fake-username',
+                                   password='fake-password')
+        operations.add(appliance)
+        shared = operations.get_shared_appliances('fake-tenant')
+
+        self.assertEqual([], shared)

--- a/a10_neutron_lbaas/tests/db/test_scheduling_hooks.py
+++ b/a10_neutron_lbaas/tests/db/test_scheduling_hooks.py
@@ -1,0 +1,60 @@
+# Copyright 2015,  A10 Networks
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.from neutron.db import model_base
+
+import mock
+
+import test_base
+
+import a10_neutron_lbaas.db.operations as db_operations
+import a10_neutron_lbaas.inventory as inventory
+import a10_neutron_lbaas.scheduling_hooks as scheduling_hooks
+
+
+class TestDevicePerTenant(test_base.UnitTestBase):
+
+    def a10_context(self):
+        session = self.open_session()
+        operations = db_operations.Operations(mock.MagicMock(session=session))
+
+        a10 = mock.MagicMock(
+            db_operations=operations,
+            openstack_context=mock.MagicMock(session=session))
+        a10.a10_driver.config.devices.__getitem__.side_effect = lambda x: {'key': x}
+
+        a10.inventory = inventory.InventoryBase(a10)
+
+        return a10
+
+    def test_select_appliance_remembers_tenant_appliance(self):
+        a10 = self.a10_context()
+        a10.tenant_id = 'fake-tenant-id'
+
+        mock1 = mock.MagicMock()
+        mock1.select_devices.return_value = [{
+            'host': 'fake-host',
+            'api_version': 'fake-version',
+            'username': 'fake-username',
+            'password': 'fake-password'}]
+        target1 = scheduling_hooks.DevicePerTenant(mock1)
+        devices1 = target1.select_devices(a10, [])
+        device1 = next(devices1.__iter__())
+
+        mock2 = mock.MagicMock()
+        target2 = scheduling_hooks.DevicePerTenant(mock2)
+        devices2 = target2.select_devices(a10, [])
+        device2 = next(devices2.__iter__())
+
+        mock2.select_devices.assert_not_called()
+
+        self.assertEqual(device1, device2)

--- a/a10_neutron_lbaas/tests/db/test_scheduling_hooks.py
+++ b/a10_neutron_lbaas/tests/db/test_scheduling_hooks.py
@@ -10,10 +10,11 @@
 #    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
-#    under the License.from neutron.db import model_base
+#    under the License.
 
 import mock
 
+from a10_neutron_lbaas.tests.unit import unit_config
 import test_base
 
 import a10_neutron_lbaas.db.operations as db_operations
@@ -27,9 +28,12 @@ class TestDevicePerTenant(test_base.UnitTestBase):
         session = self.open_session()
         operations = db_operations.Operations(mock.MagicMock(session=session))
 
+        config = unit_config.empty_config()
+
         a10 = mock.MagicMock(
             db_operations=operations,
             openstack_context=mock.MagicMock(session=session))
+        a10.a10_driver.config.device_defaults = config.device_defaults
         a10.a10_driver.config.devices.__getitem__.side_effect = lambda x: {'key': x}
 
         a10.inventory = inventory.InventoryBase(a10)

--- a/a10_neutron_lbaas/tests/db/v1/test_inventory.py
+++ b/a10_neutron_lbaas/tests/db/v1/test_inventory.py
@@ -29,24 +29,47 @@ class TestInventory(test_base.UnitTestBase):
         a10_context = mock.MagicMock(
             db_operations=operations,
             openstack_context=mock.MagicMock(session=session))
+        a10_context.a10_driver.config.devices.__getitem__.side_effect = lambda x: {'key': x}
 
-        return inventory.InventoryV1(a10_context)
+        i = inventory.InventoryV1(a10_context)
+        a10_context.inventory = i
+
+        return i
 
     def test_find_selects_appliance(self):
         target = self.inventory()
         appliance = target.db_operations.summon_appliance_configured('fake-device-key')
         target.a10_context.tenant_id = 'fake-tenant-id'
-        target.a10_context.a10_driver._select_a10_device.return_value = {'key': 'fake-device-key'}
+        scheduling_hooks = target.a10_context.a10_driver.scheduling_hooks
+        scheduling_hooks.select_devices.return_value = [{'appliance': appliance}]
 
         openstack_lbaas_object = mock.MagicMock()
         found_appliance = target.find(openstack_lbaas_object)
 
         self.assertEqual(appliance, found_appliance)
 
+    def test_find_creates_appliance(self):
+        target = self.inventory()
+        target.a10_context.tenant_id = 'fake-tenant-id'
+        scheduling_hooks = target.a10_context.a10_driver.scheduling_hooks
+        scheduling_hooks.select_devices.return_value = [{
+            'host': 'fake-host',
+            'api_version': 'fake-version',
+            'username': 'fake-username',
+            'password': 'fake-password'}]
+
+        openstack_lbaas_object = mock.MagicMock()
+        found_appliance1 = target.find(openstack_lbaas_object)
+        found_appliance2 = target.find(openstack_lbaas_object)
+
+        self.assertEqual(found_appliance1, found_appliance2)
+
     def test_find_remembers_appliance(self):
         target1 = self.inventory()
         target1.a10_context.tenant_id = 'fake-tenant-id'
-        target1.a10_context.a10_driver._select_a10_device.return_value = {'key': 'fake-device-key'}
+        appliance1 = target1.db_operations.summon_appliance_configured('fake-device-key')
+        scheduling_hooks1 = target1.a10_context.a10_driver.scheduling_hooks
+        scheduling_hooks1.select_devices.return_value = [{'appliance': appliance1}]
 
         openstack_lbaas_object = mock.MagicMock()
         target1.find(openstack_lbaas_object)
@@ -54,7 +77,11 @@ class TestInventory(test_base.UnitTestBase):
 
         target2 = self.inventory()
         target2.a10_context.tenant_id = 'fake-tenant-id'
-        target2.a10_context.a10_driver._select_a10_device.return_value = {'key': 'other-device-key'}
+        appliance2 = target2.db_operations.summon_appliance_configured('other-device-key')
+        scheduling_hooks2 = target2.a10_context.a10_driver.scheduling_hooks
+        scheduling_hooks2.select_devices.return_value = [{'appliance': appliance2}]
         found_appliance = target2.find(openstack_lbaas_object)
+
+        scheduling_hooks2.select_devices.assert_not_called()
 
         self.assertEqual('fake-device-key', found_appliance.device_key)

--- a/a10_neutron_lbaas/tests/db/v1/test_inventory.py
+++ b/a10_neutron_lbaas/tests/db/v1/test_inventory.py
@@ -15,6 +15,7 @@
 import mock
 
 import a10_neutron_lbaas.tests.db.test_base as test_base
+from a10_neutron_lbaas.tests.unit import unit_config
 
 import a10_neutron_lbaas.db.operations as db_operations
 import a10_neutron_lbaas.v1.inventory as inventory
@@ -26,10 +27,13 @@ class TestInventory(test_base.UnitTestBase):
         session = self.open_session()
         operations = db_operations.Operations(mock.MagicMock(session=session))
 
+        config = unit_config.empty_config()
+
         a10_context = mock.MagicMock(
             db_operations=operations,
             openstack_context=mock.MagicMock(session=session))
         a10_context.a10_driver.config.devices.__getitem__.side_effect = lambda x: {'key': x}
+        a10_context.a10_driver.config.device_defaults = config.device_defaults
 
         i = inventory.InventoryV1(a10_context)
         a10_context.inventory = i

--- a/a10_neutron_lbaas/tests/db/v2/test_inventory.py
+++ b/a10_neutron_lbaas/tests/db/v2/test_inventory.py
@@ -36,18 +36,36 @@ class TestInventory(test_base.UnitTestBase):
         target = self.inventory()
         appliance = target.db_operations.summon_appliance_configured('fake-device-key')
         target.a10_context.tenant_id = 'fake-tenant-id'
-        target.a10_context.a10_driver._select_a10_device.return_value = {'key': 'fake-device-key'}
+        scheduling_hooks = target.a10_context.a10_driver.scheduling_hooks
+        scheduling_hooks.select_devices.return_value = [{'appliance': appliance}]
 
         openstack_lbaas_object = mock.MagicMock(root_loadbalancer=mock.MagicMock(id='fake-lb-id'))
         found_appliance = target.find(openstack_lbaas_object)
 
         self.assertEqual(appliance, found_appliance)
 
+    def test_find_creates_appliance(self):
+        target = self.inventory()
+        target.a10_context.tenant_id = 'fake-tenant-id'
+        scheduling_hooks = target.a10_context.a10_driver.scheduling_hooks
+        scheduling_hooks.select_devices.return_value = [{
+            'host': 'fake-host',
+            'api_version': 'fake-version',
+            'username': 'fake-username',
+            'password': 'fake-password'}]
+
+        openstack_lbaas_object = mock.MagicMock(root_loadbalancer=mock.MagicMock(id='fake-lb-id'))
+        found_appliance1 = target.find(openstack_lbaas_object)
+        found_appliance2 = target.find(openstack_lbaas_object)
+
+        self.assertEqual(found_appliance1, found_appliance2)
+
     def test_find_creates_slb(self):
         target = self.inventory()
         appliance = target.db_operations.summon_appliance_configured('fake-device-key')
         target.a10_context.tenant_id = 'fake-tenant-id'
-        target.a10_context.a10_driver._select_a10_device.return_value = {'key': 'fake-device-key'}
+        scheduling_hooks = target.a10_context.a10_driver.scheduling_hooks
+        scheduling_hooks.select_devices.return_value = [{'appliance': appliance}]
 
         openstack_lbaas_object = mock.MagicMock(root_loadbalancer=mock.MagicMock(id='fake-lb-id'))
         target.find(openstack_lbaas_object)
@@ -58,8 +76,10 @@ class TestInventory(test_base.UnitTestBase):
 
     def test_find_finds_slb(self):
         target1 = self.inventory()
+        appliance = target1.db_operations.summon_appliance_configured('fake-device-key')
         target1.a10_context.tenant_id = 'fake-tenant-id'
-        target1.a10_context.a10_driver._select_a10_device.return_value = {'key': 'fake-device-key'}
+        scheduling_hooks = target1.a10_context.a10_driver.scheduling_hooks
+        scheduling_hooks.select_devices.return_value = [{'appliance': appliance}]
 
         openstack_lbaas_object = mock.MagicMock(root_loadbalancer=mock.MagicMock(id='fake-lb-id'))
         target1.find(openstack_lbaas_object)
@@ -67,24 +87,5 @@ class TestInventory(test_base.UnitTestBase):
 
         target2 = self.inventory()
         found_appliance = target2.find(openstack_lbaas_object)
-
-        self.assertEqual('fake-device-key', found_appliance.device_key)
-
-    def test_find_remembers_tenant_appliance(self):
-        target1 = self.inventory()
-        target1.a10_context.tenant_id = 'fake-tenant-id'
-        target1.a10_context.a10_driver._select_a10_device.return_value = {'key': 'fake-device-key'}
-
-        openstack_lbaas_object1 = mock.MagicMock(root_loadbalancer=mock.MagicMock(id='fake-lb-id'))
-        target1.find(openstack_lbaas_object1)
-        target1.db_operations.session.commit()
-
-        target2 = self.inventory()
-        target2.a10_context.tenant_id = 'fake-tenant-id'
-
-        openstack_lbaas_object2 = mock.MagicMock(root_loadbalancer=mock.MagicMock(id='other-lb-id'))
-        found_appliance = target2.find(openstack_lbaas_object2)
-
-        target2.a10_context.a10_driver._select_a10_device.assert_not_called()
 
         self.assertEqual('fake-device-key', found_appliance.device_key)

--- a/a10_neutron_lbaas/tests/db/v2/test_inventory.py
+++ b/a10_neutron_lbaas/tests/db/v2/test_inventory.py
@@ -15,6 +15,7 @@
 import mock
 
 import a10_neutron_lbaas.tests.db.test_base as test_base
+from a10_neutron_lbaas.tests.unit import unit_config
 
 import a10_neutron_lbaas.db.operations as db_operations
 import a10_neutron_lbaas.v2.inventory as inventory
@@ -26,9 +27,12 @@ class TestInventory(test_base.UnitTestBase):
         session = self.open_session()
         operations = db_operations.Operations(mock.MagicMock(session=session))
 
+        config = unit_config.empty_config()
+
         a10_context = mock.MagicMock(
             db_operations=operations,
             openstack_context=mock.MagicMock(session=session))
+        a10_context.a10_driver.config.device_defaults = config.device_defaults
 
         return inventory.InventoryV2(a10_context)
 

--- a/a10_neutron_lbaas/tests/unit/neutron_ext/common/test_resources.py
+++ b/a10_neutron_lbaas/tests/unit/neutron_ext/common/test_resources.py
@@ -1,0 +1,43 @@
+# Copyright 2016,  A10 Networks
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from a10_neutron_lbaas.tests import test_case
+
+from a10_neutron_lbaas.neutron_ext.common import resources
+
+
+class TestResources(test_case.TestCase):
+
+    def test_apply_template(self):
+        template = {
+            'none': None,
+            'integer': 1,
+            'string': 'a string',
+            'tuple': ('a tuple', lambda x: x + 1, lambda x: x + 2),
+            'dict': {'key': lambda x: x + 3},
+            'list': ['a list', lambda x: x + 4]
+        }
+
+        actual = resources.apply_template(template, 0)
+
+        expected = {
+            'none': None,
+            'integer': 1,
+            'string': 'a string',
+            'tuple': ('a tuple', 1, 2),
+            'dict': {'key': 3},
+            'list': ['a list', 4]
+        }
+
+        self.assertEqual(expected, actual)

--- a/a10_neutron_lbaas/tests/unit/test_a10_openstack_lb.py
+++ b/a10_neutron_lbaas/tests/unit/test_a10_openstack_lb.py
@@ -1,0 +1,94 @@
+# Copyright 2014, Doug Wiegley (dougwig), A10 Networks
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import mock
+
+import a10_neutron_lbaas.tests.test_case as test_case
+import a10_neutron_lbaas.tests.unit.unit_config as unit_config
+
+import a10_neutron_lbaas.a10_openstack_lb as a10_openstack_lb
+import a10_neutron_lbaas.plumbing_hooks as plumbing_hooks
+
+
+class SetupA10OpenstackLBBase(object):
+
+    @property
+    def a10_openstack_lb_class(self):
+        return a10_openstack_lb.A10OpenstackLBBase
+
+    @property
+    def a10_openstack_lb_kws(self):
+        return {}
+
+
+class SetupA10OpenstackLBV1(object):
+    @property
+    def a10_openstack_lb_class(self):
+        return a10_openstack_lb.A10OpenstackLBV1
+
+
+class SetupA10OpenstackLBV2(object):
+    @property
+    def a10_openstack_lb_class(self):
+        return a10_openstack_lb.A10OpenstackLBV2
+
+
+class SetupPlumbingHooks(object):
+    @property
+    def a10_openstack_lb_kws(self):
+        kws = super(SetupPlumbingHooks, self).a10_openstack_lb_kws
+        kws2 = kws.copy()
+        kws2['plumbing_hooks_class'] = plumbing_hooks.PlumbingHooks
+        return kws2
+
+
+class TestA10Openstack(SetupA10OpenstackLBBase, test_case.TestCase):
+
+    def setUp(self):
+        unit_config.setUp()
+
+        mock_driver = mock.MagicMock()
+        with mock.patch('acos_client.Client'):
+            self.a = self.a10_openstack_lb_class(mock_driver, **self.a10_openstack_lb_kws)
+
+    def test_sanity(self):
+        pass
+
+    def test_plumbing_hooks_for_migrations(self):
+        """The migrations need to be able to to get at the old-style plumbing hooks"""
+
+        self.assertTrue(hasattr(self.a, '_plumbing_hooks'),
+                        "The a10 driver needs to have _plumbing_hooks")
+        self.assertTrue(hasattr(self.a._plumbing_hooks, 'select_device'),
+                        "The a10 driver's _plumbing_hooks needs to have select_device")
+
+
+class TestA10OpenstackPlumbingHooks(SetupPlumbingHooks, TestA10Openstack):
+    pass
+
+
+class TestA10OpenstackV1(SetupA10OpenstackLBV1, TestA10Openstack):
+    pass
+
+
+class TestA10OpenstackV1PlumbingHooks(SetupA10OpenstackLBV1, SetupPlumbingHooks, TestA10Openstack):
+    pass
+
+
+class TestA10OpenstackV2(SetupA10OpenstackLBV2, TestA10Openstack):
+    pass
+
+
+class TestA10OpenstackV2PlumbingHooks(SetupA10OpenstackLBV2, SetupPlumbingHooks, TestA10Openstack):
+    pass

--- a/a10_neutron_lbaas/tests/unit/test_base.py
+++ b/a10_neutron_lbaas/tests/unit/test_base.py
@@ -12,13 +12,11 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-import os
-
 import a10_neutron_lbaas.tests.test_case as test_case
+import a10_neutron_lbaas.tests.unit.unit_config as unit_config
 import mock
 
 import a10_neutron_lbaas.a10_openstack_lb as a10_os
-import a10_neutron_lbaas.plumbing_hooks as hooks
 
 
 def _build_openstack_context():
@@ -41,9 +39,8 @@ def _build_inventory_mock():
     (inventory_class, inventory_mock) = _build_class_instance_mock()
 
     def find(openstack_lbaas_obj):
-        print (inventory_class.call_args)
         ((a10_context,), _) = inventory_class.call_args
-        device = a10_context.a10_driver._select_a10_device(a10_context.tenant_id)
+        device = a10_context.a10_driver.config.devices.values()[0]
         appliance = mock.MagicMock()
         appliance.device.return_value = device
         return appliance
@@ -71,7 +68,6 @@ class FakeA10OpenstackLB(object):
     def _get_a10_client(self, device_info):
         self.device_info = device_info
         self.last_client = mock.MagicMock()
-        self.plumbing_hooks = hooks.PlumbingHooks(self)
         return self.last_client
 
     def reset_mocks(self):
@@ -100,9 +96,7 @@ class UnitTestBase(test_case.TestCase):
         return _build_openstack_context()
 
     def setUp(self):
-        unit_dir = os.path.dirname(__file__)
-        unit_config = os.path.join(unit_dir, "unit_config")
-        os.environ['A10_CONFIG_DIR'] = unit_config
+        unit_config.setUp()
 
         if not hasattr(self, 'version') or self.version == 'v2':
             self.a = FakeA10OpenstackLBV2(None)

--- a/a10_neutron_lbaas/tests/unit/test_plumbing_hooks.py
+++ b/a10_neutron_lbaas/tests/unit/test_plumbing_hooks.py
@@ -1,0 +1,27 @@
+# Copyright 2014, Doug Wiegley (dougwig), A10 Networks
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import test_base
+
+from a10_neutron_lbaas import plumbing_hooks
+
+
+class TestPlumbingHooks(test_base.UnitTestBase):
+
+    def test_select_device(self):
+        hooks = plumbing_hooks.PlumbingHooks(self.a)
+
+        a = hooks.select_device("first-token")
+        hooks.select_device("second-token")
+        self.assertEqual(a, hooks.select_device("first-token"))

--- a/a10_neutron_lbaas/tests/unit/unit_config/__init__.py
+++ b/a10_neutron_lbaas/tests/unit/unit_config/__init__.py
@@ -14,7 +14,15 @@
 
 import os
 
+from a10_neutron_lbaas import a10_config
+from a10_neutron_lbaas.install import blank_config
+
 
 def setUp():
     unit_dir = os.path.dirname(__file__)
     os.environ['A10_CONFIG_DIR'] = unit_dir
+
+
+def empty_config():
+    config_dir = os.path.dirname(blank_config.__file__)
+    return a10_config.A10Config(config_dir=config_dir)

--- a/a10_neutron_lbaas/tests/unit/unit_config/__init__.py
+++ b/a10_neutron_lbaas/tests/unit/unit_config/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2014, Doug Wiegley (dougwig), A10 Networks
+# Copyright 2015,  A10 Networks
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
 #    not use this file except in compliance with the License. You may obtain
@@ -10,15 +10,11 @@
 #    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
-#    under the License.
+#    under the License.from neutron.db import model_base
 
-import test_base
+import os
 
 
-class TestA10Openstack(test_base.UnitTestBase):
-
-    def test_sanity(self):
-        pass
-
-    def test_verify(self):
-        self.a._verify_appliances()
+def setUp():
+    unit_dir = os.path.dirname(__file__)
+    os.environ['A10_CONFIG_DIR'] = unit_dir

--- a/a10_neutron_lbaas/tests/unit/v2/test_a10_openstack.py
+++ b/a10_neutron_lbaas/tests/unit/v2/test_a10_openstack.py
@@ -20,10 +20,5 @@ class TestA10Openstack(test_base.UnitTestBase):
     def test_sanity(self):
         pass
 
-    def test_select(self):
-        a = self.a._select_a10_device("first-token")
-        self.a._select_a10_device("second-token")
-        self.assertEqual(a, self.a._select_a10_device("first-token"))
-
     def test_verify(self):
         self.a._verify_appliances()

--- a/a10_neutron_lbaas_client/resources/a10_appliance.py
+++ b/a10_neutron_lbaas_client/resources/a10_appliance.py
@@ -78,13 +78,22 @@ RESOURCE_ATTRIBUTE_MAP = {
             },
             'is_visible': False
         },
+        'api_version': {
+            'allow_post': True,
+            'allow_put': True,
+            'validate': {
+                'type:values': ['2.1', '3.0']
+            },
+            'is_visible': True
+        },
         'protocol': {
             'allow_post': True,
             'allow_put': True,
             'validate': {
-                'type:string': None
+                'type:values': ['http', 'https']
             },
             'is_visible': True,
+            'convert_to': lambda attr: convert_to_lower,
             'default': lambda attr: attr.ATTR_NOT_SPECIFIED
         },
         'port': {
@@ -99,3 +108,10 @@ RESOURCE_ATTRIBUTE_MAP = {
         }
     }
 }
+
+
+def convert_to_lower(input):
+    try:
+        return input.lower()
+    except AttributeError:
+        return input

--- a/a10_neutron_lbaas_client/resources/a10_appliance.py
+++ b/a10_neutron_lbaas_client/resources/a10_appliance.py
@@ -78,13 +78,24 @@ RESOURCE_ATTRIBUTE_MAP = {
             },
             'is_visible': False
         },
-        'api_version': {
+        'protocol': {
             'allow_post': True,
             'allow_put': True,
             'validate': {
                 'type:string': None
             },
-            'is_visible': True
+            'is_visible': True,
+            'default': lambda attr: attr.ATTR_NOT_SPECIFIED
+        },
+        'port': {
+            'allow_post': True,
+            'allow_put': True,
+            'validate': {
+                'type:range': [0, 65535]
+            },
+            'convert_to': lambda attr: attr.convert_to_int,
+            'is_visible': True,
+            'default': lambda attr: attr.ATTR_NOT_SPECIFIED
         }
     }
 }


### PR DESCRIPTION
Scheduling Refactor and Database Appliance Scheduling

Story #135

By default, the driver now selects a database appliance owned by the current tenant if possible.
If the driver is initialized with a plumbing_hooks_class it uses the plumbing hooks' select_device.

Refactor of inventory and hooks to enable custom scheduling.
Plumbing Hooks has been split into two interfaces, network hooks and scheduling hooks.
Scheduling hooks returns an iterable of devices on which a new object can be created.

Scheduling hooks can return devices that aren't in the config or in the inventory.
The inital use of this is to select a database appliance owned by the tenant.
If the device returned from scheduling hooks isn't in the appliance inventory, it's added as an
a10 appliance db. Only the required configuration can be saved in a10 appliance db.
TODO: We need to add explicit support for each of our configuration options to the database model, Inventory device_appliance.

We'll likely change the scheduling hooks interface somewhat before reintegrating orchestration.

----

* simplified inventory mock for unit tests
* Expose old plumbing hooks as _plumbing_hooks so it's available to the migrations
* Tests for inventory/scheduling hooks refactor
* a10_context/inventory interaction tests