### PR TITLE
Populate a10_tenant_appliance for established tenants

### DIFF
--- a/a10_neutron_lbaas/db/migration/alembic_migrations/lbaasv1/4657b284f454_populate_vip_appliances.py
+++ b/a10_neutron_lbaas/db/migration/alembic_migrations/lbaasv1/4657b284f454_populate_vip_appliances.py
@@ -26,23 +26,13 @@ down_revision = '38bfe6f0fe53'
 branch_labels = None
 depends_on = None
 
-from alembic import context
-from alembic import op
-
-from a10_neutron_lbaas import A10OpenstackLBV1
-from a10_neutron_lbaas.db.migration.step import initialize_a10_slb_v1
-import neutron.plugins.common.constants as constants
-
 
 def upgrade():
-    for provider, driver in context.config.drivers[constants.LOADBALANCER][0].items():
-        if hasattr(driver, 'a10') and isinstance(driver.a10, A10OpenstackLBV1):
-            upgrade_driver(provider, driver.a10)
+    """This step moved to populate vip, tenant appliances
+    to also populate the a10_tenant_appliance table
+    """
 
-
-def upgrade_driver(provider, a10):
-    conn = op.get_bind()
-    initialize_a10_slb_v1(conn, provider, a10)
+    pass
 
 
 def downgrade():

--- a/a10_neutron_lbaas/db/migration/alembic_migrations/lbaasv1/5a960cad849b_populate_vip_tenant_applianaces.py
+++ b/a10_neutron_lbaas/db/migration/alembic_migrations/lbaasv1/5a960cad849b_populate_vip_tenant_applianaces.py
@@ -1,0 +1,49 @@
+# Copyright 2015,  A10 Networks
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+"""populate vip, tenant applianaces
+
+Revision ID: 5a960cad849b
+Revises: 4657b284f454
+Create Date: 2015-12-21 18:23:57.636375
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '5a960cad849b'
+down_revision = '4657b284f454'
+branch_labels = None
+depends_on = '28a984ff83e1'
+
+from alembic import context
+from alembic import op
+
+from a10_neutron_lbaas import A10OpenstackLBV1
+from a10_neutron_lbaas.db.migration.step import initialize_a10_slb_v1
+import neutron.plugins.common.constants as constants
+
+
+def upgrade():
+    for provider, driver in context.config.drivers[constants.LOADBALANCER][0].items():
+        if hasattr(driver, 'a10') and isinstance(driver.a10, A10OpenstackLBV1):
+            upgrade_driver(provider, driver.a10)
+
+
+def upgrade_driver(provider, a10):
+    conn = op.get_bind()
+    initialize_a10_slb_v1(conn, provider, a10)
+
+
+def downgrade():
+    pass

--- a/a10_neutron_lbaas/db/migration/alembic_migrations/lbaasv2/2024607c4f06_populate_loadbalancer_tenant_applianaces.py
+++ b/a10_neutron_lbaas/db/migration/alembic_migrations/lbaasv2/2024607c4f06_populate_loadbalancer_tenant_applianaces.py
@@ -1,0 +1,49 @@
+# Copyright 2015,  A10 Networks
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+"""populate loadbalancer, tenant applianaces
+
+Revision ID: 2024607c4f06
+Revises: 520d563f3642
+Create Date: 2015-12-21 18:24:13.290218
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '2024607c4f06'
+down_revision = '520d563f3642'
+branch_labels = None
+depends_on = '28a984ff83e1'
+
+from alembic import context
+from alembic import op
+
+from a10_neutron_lbaas import A10OpenstackLBV2
+from a10_neutron_lbaas.db.migration.step import initialize_a10_slb_v2
+import neutron.plugins.common.constants as constants
+
+
+def upgrade():
+    for provider, driver in context.config.drivers[constants.LOADBALANCERV2][0].items():
+        if hasattr(driver, 'a10') and isinstance(driver.a10, A10OpenstackLBV2):
+            upgrade_driver(provider, driver.a10)
+
+
+def upgrade_driver(provider, a10):
+    conn = op.get_bind()
+    initialize_a10_slb_v2(conn, provider, a10)
+
+
+def downgrade():
+    pass

--- a/a10_neutron_lbaas/db/migration/alembic_migrations/lbaasv2/520d563f3642_populate_loadbalancer_appliances.py
+++ b/a10_neutron_lbaas/db/migration/alembic_migrations/lbaasv2/520d563f3642_populate_loadbalancer_appliances.py
@@ -26,23 +26,13 @@ down_revision = '3f6b367e2485'
 branch_labels = None
 depends_on = None
 
-from alembic import context
-from alembic import op
-
-from a10_neutron_lbaas import A10OpenstackLBV2
-from a10_neutron_lbaas.db.migration.step import initialize_a10_slb_v2
-import neutron.plugins.common.constants as constants
-
 
 def upgrade():
-    for provider, driver in context.config.drivers[constants.LOADBALANCERV2][0].items():
-        if hasattr(driver, 'a10') and isinstance(driver.a10, A10OpenstackLBV2):
-            upgrade_driver(provider, driver.a10)
+    """This step moved to populate loadbalancer, tenant appliances
+    to also populate the a10_tenant_appliance table
+    """
 
-
-def upgrade_driver(provider, a10):
-    conn = op.get_bind()
-    initialize_a10_slb_v2(conn, provider, a10)
+    pass
 
 
 def downgrade():

--- a/a10_neutron_lbaas/db/migration/cli.py
+++ b/a10_neutron_lbaas/db/migration/cli.py
@@ -65,15 +65,27 @@ def do_query(config, cmd):
                        verbose=CONF.command.verbose)
 
 
-def do_upgrade_downgrade(config, cmd):
+def do_upgrade(config, cmd):
     if not CONF.command.revision and not CONF.command.delta:
         raise SystemExit(_('You must provide a revision or relative delta'))
 
-    revision = CONF.command.revision
+    if CONF.command.delta:
+        revision = '+' + str(CONF.command.delta)
+    else:
+        revision = CONF.command.revision
+
+    if CONF.command.sql:
+        do_alembic_command(config, cmd, revision, sql=CONF.command.sql)
+    else:
+        _install(config, revision)
+
+
+def do_downgrade(config, cmd):
+    if not CONF.command.revision and not CONF.command.delta:
+        raise SystemExit(_('You must provide a revision or relative delta'))
 
     if CONF.command.delta:
-        sign = '+' if CONF.command.name == 'upgrade' else '-'
-        revision = sign + str(CONF.command.delta)
+        revision = '-' + str(CONF.command.delta)
     else:
         revision = CONF.command.revision
 
@@ -241,12 +253,17 @@ def add_command_parsers(subparsers):
         parser.add_argument('--verbose', action='store_true')
         parser.set_defaults(func=do_query)
 
-    for name in ['upgrade', 'downgrade']:
-        parser = subparsers.add_parser(name)
-        parser.add_argument('--delta', type=int)
-        parser.add_argument('--sql', action='store_true')
-        parser.add_argument('revision', nargs='?')
-        parser.set_defaults(func=do_upgrade_downgrade)
+    parser = subparsers.add_parser('upgrade')
+    parser.add_argument('--delta', type=int)
+    parser.add_argument('--sql', action='store_true')
+    parser.add_argument('revision', nargs='?')
+    parser.set_defaults(func=do_upgrade)
+
+    parser = subparsers.add_parser('downgrade')
+    parser.add_argument('--delta', type=int)
+    parser.add_argument('--sql', action='store_true')
+    parser.add_argument('revision', nargs='?')
+    parser.set_defaults(func=do_downgrade)
 
     parser = subparsers.add_parser('stamp')
     parser.add_argument('--sql', action='store_true')

--- a/a10_neutron_lbaas/db/migration/step.py
+++ b/a10_neutron_lbaas/db/migration/step.py
@@ -12,7 +12,6 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-import itertools
 from sqlalchemy.sql import table, column, text
 import uuid
 
@@ -48,10 +47,34 @@ def initialize_a10_appliances_configured(conn, config):
     return appliance_lookup
 
 
-def initialize_a10_slb_v1(conn, provider, a10):
-    """Create a10_slb_v1 for existing vips"""
+def initialize_a10_tenant_appliance(conn, a10, tenant_ids):
 
     appliance_lookup = initialize_a10_appliances_configured(conn, a10.config)
+
+    a10_tenant_appliance = table(
+        'a10_tenant_appliance',
+        column('tenant_id'),
+        column('a10_appliance_id'))
+    select_tenant_appliance = a10_tenant_appliance.select()
+    tenant_appliances = conn.execute(select_tenant_appliance).fetchall()
+    tenant_appliance_lookup = dict((a.tenant_id, a.a10_appliance_id) for a in tenant_appliances)
+
+    for tenant_id in tenant_ids:
+        if tenant_id not in tenant_appliance_lookup:
+            device = a10.hooks.select_device(tenant_id)
+            appliance_id = appliance_lookup[device['key']]
+
+            insert_tenant_appliance = a10_tenant_appliance.insert().\
+                values(tenant_id=tenant_id, a10_appliance_id=appliance_id)
+            conn.execute(insert_tenant_appliance)
+
+            tenant_appliance_lookup[tenant_id] = appliance_id
+
+    return tenant_appliance_lookup
+
+
+def initialize_a10_slb_v1(conn, provider, a10):
+    """Create a10_slb_v1 for existing vips"""
 
     a10_slb_v1 = table(
         'a10_slb_v1',
@@ -65,7 +88,10 @@ def initialize_a10_slb_v1(conn, provider, a10):
         "AND p.provider_name = :provider "
         "AND vips.id NOT IN (SELECT vip_id FROM a10_slb_v1)")
     select_vips = select_vips.bindparams(provider=provider)
-    vips = itertools.imap(dict, conn.execute(select_vips).fetchall())
+    vips = list(map(dict, conn.execute(select_vips).fetchall()))
+
+    tenant_ids = [v['tenant_id'] for v in vips]
+    tenant_appliance_lookup = initialize_a10_tenant_appliance(conn, a10, tenant_ids)
 
     a10_slb = table(
         'a10_slb',
@@ -74,8 +100,7 @@ def initialize_a10_slb_v1(conn, provider, a10):
         column('a10_appliance_id'))
     for vip in vips:
         id = str(uuid.uuid4())
-        device = a10.hooks.select_device(vip['tenant_id'])
-        appliance = appliance_lookup[device['key']]
+        appliance = tenant_appliance_lookup[vip['tenant_id']]
         insert_slb = a10_slb.insert().\
             values(id=id, type=a10_slb_v1.name, a10_appliance_id=appliance)
         conn.execute(insert_slb)
@@ -86,8 +111,6 @@ def initialize_a10_slb_v1(conn, provider, a10):
 
 def initialize_a10_slb_v2(conn, provider, a10):
     """Create a10_slb_v2 for existing loadbalancers"""
-
-    appliance_lookup = initialize_a10_appliances_configured(conn, a10.config)
 
     a10_slb_v2 = table(
         'a10_slb_v2',
@@ -100,7 +123,10 @@ def initialize_a10_slb_v2(conn, provider, a10):
         "AND p.provider_name = :provider "
         "AND lb.id NOT IN (SELECT lbaas_loadbalancer_id FROM a10_slb_v2)")
     select_lbs = select_lbs.bindparams(provider=provider)
-    lbs = itertools.imap(dict, conn.execute(select_lbs).fetchall())
+    lbs = list(map(dict, conn.execute(select_lbs).fetchall()))
+
+    tenant_ids = [lb['tenant_id'] for lb in lbs]
+    tenant_appliance_lookup = initialize_a10_tenant_appliance(conn, a10, tenant_ids)
 
     a10_slb = table(
         'a10_slb',
@@ -109,8 +135,7 @@ def initialize_a10_slb_v2(conn, provider, a10):
         column('a10_appliance_id'))
     for lb in lbs:
         id = str(uuid.uuid4())
-        device = a10.hooks.select_device(lb['tenant_id'])
-        appliance = appliance_lookup[device['key']]
+        appliance = tenant_appliance_lookup[lb['tenant_id']]
         insert_slb = a10_slb.insert().\
             values(id=id, type=a10_slb_v2.name, a10_appliance_id=appliance)
         conn.execute(insert_slb)


### PR DESCRIPTION
Story #145

Populates a10_tenant_appliance when populating vip and loadbalancer appliances. Fixes an issue where, if the db migrations are run and a new appliance is added before a tenant is assigned to an aplliance, the tenant might be assigned to a different appliance than their existing lbaas objects.

----

 * Test for, migrations populate a10_tenant_appliance
 * Migration populations happen later in the migration process. The existing migration steps are now stubs that exist just for versioning compatibility.
 * Migration cli upgrade uses the fixed _install method, since the alembic upgrade method is broken (https://bitbucket.org/zzzeek/alembic/issues/336) when using branches. This fixes the order-of-upgrade tests that assumed upgrade would actually work.