### PR TITLE
Fixed logged-in tenant versus selected tenant

### DIFF
--- a/a10_neutron_lbaas/instance_manager.py
+++ b/a10_neutron_lbaas/instance_manager.py
@@ -96,12 +96,18 @@ class InstanceManager(object):
             raise AttributeError("FATAL: Service catalog not populated.")
         for x in token.serviceCatalog:
             # This is always returned as an array.
-            endpoints = x.get("endpoints", [{}])
-            endpoint_filter = lambda x: x.get("interface") in OS_INTERFACE_URLS
-            endpoint = filter(endpoint_filter, endpoints)
-            if len(endpoint) > 0:
-                res[x["type"]] = endpoint[0].get("url")
+            endpoints = x.get("endpoints", [])
+            urls = map(self.endpoint_public_url, endpoints)
+            urls = filter(lambda x: x is not None, urls)
+
+            if len(urls) > 0:
+                res[x["type"]] = urls[0]
         return res
+
+    def endpoint_public_url(self, endpoint):
+        if endpoint.get('interface') == 'public':
+            return endpoint['url']
+        return endpoint.get('publicURL')
 
     def _get_auth_from_token(self, token):
         auth_url = None

--- a/a10_neutron_lbaas/instance_manager.py
+++ b/a10_neutron_lbaas/instance_manager.py
@@ -35,7 +35,7 @@ GLANCE_VERSION = 1
 KEYSTONE_VERSION = "2.0"
 NOVA_VERSION = "2.1"
 NEUTRON_VERSION = "2.0"
-OS_INTERFACE_URL = "public"
+OS_INTERFACE_URLS = ["public", "publicURL"]
 
 _default_server = {
     "id": None,
@@ -97,7 +97,7 @@ class InstanceManager(object):
         for x in token.serviceCatalog:
             # This is always returned as an array.
             endpoints = x.get("endpoints", [{}])
-            endpoint_filter = lambda x: x.get("interface") == OS_INTERFACE_URL
+            endpoint_filter = lambda x: x.get("interface") in OS_INTERFACE_URLS
             endpoint = filter(endpoint_filter, endpoints)
             if len(endpoint) > 0:
                 res[x["type"]] = endpoint[0].get("url")

--- a/a10_neutron_lbaas/tests/unit/test_instance_manager.py
+++ b/a10_neutron_lbaas/tests/unit/test_instance_manager.py
@@ -74,10 +74,13 @@ class TestInstanceManager(test_base.UnitTestBase):
         self.service_catalog = [{
             "name": "keystone",
             "type": "identity",
-            "endpoints": [{"publicURL": "http://localhost:5000"}]
+            "endpoints": [{
+                "interface": "public",
+                "url": "http://localhost:5000"}]
         }]
 
-        self.token = mock.NonCallableMock(serviceCatalog=self.service_catalog)
+        project = {"id": "fakeid", "name": "Carl Adultman"}
+        self.token = mock.NonCallableMock(serviceCatalog=self.service_catalog, project=project)
         self.user = mock.NonCallableMock(token=self.token)
         self.request = mock.NonCallableMock(user=self.user)
 


### PR DESCRIPTION
Also fixed endpoint selection.  I need to test this against OS releases I-K to ensure endpoint selection isn't broken for previous versions.  Integration tests will likely be required given the nature of the issue (different response shapes depending on identity api ver, it appears - hence the need to test).

tox also kept bombing regarding a missing requirement for neutron-lbaas... checking to see if Travis is able to run the tests as I can't run them at all locally.