### PR TITLE
Moved image defaults to a10config

### DIFF
--- a/a10_neutron_lbaas/a10_config.py
+++ b/a10_neutron_lbaas/a10_config.py
@@ -33,6 +33,19 @@ class A10Config(object):
         "method": "hash"
     }
 
+    IMAGE_DEFAULTS = {
+        "name": None,
+        "id": None,
+        "visibility": "private",
+        "tags": ["a10"],
+        "properties": None,
+        "container_format": "bare",
+        "disk_format": "qcow2",
+        "min_disk": 10,
+        "min_ram": 4096,
+        "protected": False
+    }
+
     def __init__(self):
         if os.path.exists('/etc/a10'):
             d = '/etc/a10'
@@ -71,16 +84,12 @@ class A10Config(object):
                         if dk not in self.devices[k]:
                             self.devices[k][dk] = dv
 
-            self.image_defaults = {}
-            self._populate_image_defaults()
+            self.image_defaults = self.IMAGE_DEFAULTS.copy()
+            self.image_defaults.update(getattr(self.config, "image_defaults", {}))
         finally:
             sys.path = real_sys_path
 
         LOG.debug("A10Config, devices=%s", self.devices)
-
-    def _populate_image_defaults(self):
-        for k, v in self.config.image_defaults.items():
-            self.image_defaults[k] = v
 
     @property
     def verify_appliances(self):

--- a/a10_neutron_lbaas/tests/unit/test_a10_config.py
+++ b/a10_neutron_lbaas/tests/unit/test_a10_config.py
@@ -62,9 +62,3 @@ class TestA10Config(test_base.UnitTestBase):
                     "min_ram", "container_format", "protected",
                     "properties", "disk_format"]
         self.assertListEqual(sorted(expected), sorted(actual))
-
-    def test_image_default_properties_parses(self):
-        import json
-        properties = self.a.config.image_defaults.get("properties")
-        actual = json.loads(properties)
-        self.assertIsNotNone(actual)

--- a/a10_neutron_lbaas/tests/unit/unit_config/config.py
+++ b/a10_neutron_lbaas/tests/unit/unit_config/config.py
@@ -115,15 +115,3 @@ devices = {
     },
 }
 
-image_defaults = {
-    "name": None,
-    "id": None,
-    "visibility": "private",
-    "tags": ["a10"],
-    "properties": '{"username": "dude", "password": "password", "api_version": "api_version"}',
-    "container_format": "bare",
-    "disk_format": "qcow2",
-    "min_disk": 10,
-    "min_ram": 4096,
-    "protected": False
-}


### PR DESCRIPTION
This is less flexible than the defaults being in config.py and will likely need to be configured.

Didn't update any tests because the tests still reference the `image_defaults` attribute.  I was pleased greatly by this.