### PR TITLE
Correctly delete from polymorphic tables

### DIFF
--- a/a10_neutron_lbaas/db/migration/alembic_migrations/lbaasv1/2e7daa753e19_remove_orphaned_a10_slb_v1_slb.py
+++ b/a10_neutron_lbaas/db/migration/alembic_migrations/lbaasv1/2e7daa753e19_remove_orphaned_a10_slb_v1_slb.py
@@ -1,0 +1,41 @@
+# Copyright 2015,  A10 Networks
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+"""Remove orphaned a10_slb_v1 slb
+
+Revision ID: 2e7daa753e19
+Revises: 5a960cad849b
+Create Date: 2016-01-08 23:18:54.856154
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '2e7daa753e19'
+down_revision = '5a960cad849b'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+
+
+def upgrade():
+    conn = op.get_bind()
+    conn.execute(
+        "DELETE FROM a10_slb "
+        "WHERE type='a10_slb_v1' "
+        "AND id NOT IN (SELECT id FROM a10_slb_v1)")
+
+
+def downgrade():
+    pass

--- a/a10_neutron_lbaas/db/migration/alembic_migrations/lbaasv2/163796ede8f0_remove_orphaned_a10_slb_v2_slb.py
+++ b/a10_neutron_lbaas/db/migration/alembic_migrations/lbaasv2/163796ede8f0_remove_orphaned_a10_slb_v2_slb.py
@@ -1,0 +1,41 @@
+# Copyright 2015,  A10 Networks
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+"""Remove orphaned a10_slb_v2 slb
+
+Revision ID: 163796ede8f0
+Revises: 2024607c4f06
+Create Date: 2016-01-08 23:41:39.322538
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '163796ede8f0'
+down_revision = '2024607c4f06'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+
+
+def upgrade():
+    conn = op.get_bind()
+    conn.execute(
+        "DELETE FROM a10_slb "
+        "WHERE type='a10_slb_v2' "
+        "AND id NOT IN (SELECT id FROM a10_slb_v2)")
+
+
+def downgrade():
+    pass

--- a/a10_neutron_lbaas/db/models.py
+++ b/a10_neutron_lbaas/db/models.py
@@ -41,6 +41,13 @@ def summon(session, cls, **kw):
     return existing
 
 
+def delete_all(session, query):
+    """Sql-alchemy's Query.delete() doesn't remove rows from polymorphically related tables"""
+
+    for row in query:
+        session.delete(row)
+
+
 def uuid_str():
     return str(uuid.uuid4())
 

--- a/a10_neutron_lbaas/db/operations.py
+++ b/a10_neutron_lbaas/db/operations.py
@@ -32,9 +32,8 @@ class Operations(object):
             filter_by(vip_id=vip_id).first()
 
     def delete_slb_v1(self, vip_id):
-        # print 'delete_slb_v1({0})'.format(repr(vip_id))
-        return self.session.query(models.A10SLBV1).\
-            filter_by(vip_id=vip_id).delete()
+        query = self.session.query(models.A10SLBV1).filter_by(vip_id=vip_id)
+        models.delete_all(self.session, query)
 
     def get_slb_v2(self, loadbalancer_id):
         # print 'get_slb_v2({0})'.format(repr(loadbalancer_id))
@@ -42,9 +41,9 @@ class Operations(object):
             filter_by(lbaas_loadbalancer_id=loadbalancer_id).first()
 
     def delete_slb_v2(self, loadbalancer_id):
-        # print 'delete_slb_v2({0})'.format(repr(loadbalancer_id))
-        return self.session.query(models.A10SLBV2).\
-            filter_by(lbaas_loadbalancer_id=loadbalancer_id).delete()
+        query = self.session.query(models.A10SLBV2).\
+            filter_by(lbaas_loadbalancer_id=loadbalancer_id)
+        models.delete_all(self.session, query)
 
     def get_tenant_appliance(self, tenant_id):
         return self.session.query(models.A10TenantAppliance).\

--- a/a10_neutron_lbaas/tests/db/migration/test_cli.py
+++ b/a10_neutron_lbaas/tests/db/migration/test_cli.py
@@ -164,9 +164,7 @@ class TestCLI(test_base.UnitTestBase):
         self.run_cli('install')
         self.run_cli('downgrade', 'base')
 
-    def migrate_lbaasv1_vip(self):
-        device_key = 'fake-device-key'
-        provider = 'fake-provider'
+    def add_lbaasv1_vip(self, provider):
         tenant_id = 'fake-tenant'
         status = 'FAKE'
 
@@ -205,6 +203,9 @@ class TestCLI(test_base.UnitTestBase):
         session.add(pra)
         session.commit()
 
+        return vip_id
+
+    def lbaasv1_drivers(self, device_key, provider):
         mock_config = mock.MagicMock(
             name='mock_config',
             devices={device_key: {'key': device_key}})
@@ -220,6 +221,16 @@ class TestCLI(test_base.UnitTestBase):
             name='mock_driver',
             a10=mock_a10)
         drivers = {'LOADBALANCER': ({provider: mock_driver}, provider)}
+
+        return drivers
+
+    def migrate_lbaasv1_vip(self):
+        device_key = 'fake-device-key'
+        provider = 'fake-provider'
+
+        vip_id = self.add_lbaasv1_vip(provider)
+        drivers = self.lbaasv1_drivers(device_key, provider)
+
         status = self.run_cli('install', drivers=drivers)
 
         return {
@@ -254,9 +265,29 @@ class TestCLI(test_base.UnitTestBase):
 
         self.assertEqual(tenant_appliance.a10_appliance.device_key, device_key)
 
-    def migrate_lbaasv2_vip(self):
+    def test_migration_remove_orphaned_a10_slb_v1(self):
         device_key = 'fake-device-key'
         provider = 'fake-provider'
+
+        self.add_lbaasv1_vip(provider)
+        drivers = self.lbaasv1_drivers(device_key, provider)
+
+        self.run_cli('upgrade', '5a960cad849b', drivers=drivers)
+
+        session1 = self.Session()
+        session1.execute("DELETE FROM a10_slb_v1")
+        session1.commit()
+
+        status = self.run_cli('install', drivers=drivers)
+        self.assertEqual('UPGRADED', status['core'].status)
+        self.assertEqual('UPGRADED', status['lbaasv1'].status)
+
+        session = self.Session()
+        slbs = list(session.query(models.A10SLB))
+
+        self.assertEqual([], slbs)
+
+    def add_lbaasv2_lb(self, provider):
         tenant_id = 'fake-tenant'
         status = 'FAKE'
 
@@ -285,6 +316,9 @@ class TestCLI(test_base.UnitTestBase):
         session.add(pra)
         session.commit()
 
+        return lb_id
+
+    def lbaasv2_drivers(self, provider, device_key):
         mock_config = mock.MagicMock(
             name='mock_config',
             devices={device_key: {'key': device_key}})
@@ -300,6 +334,16 @@ class TestCLI(test_base.UnitTestBase):
             name='mock_driver',
             a10=mock_a10)
         drivers = {'LOADBALANCERV2': ({provider: mock_driver}, provider)}
+
+        return drivers
+
+    def migrate_lbaasv2_vip(self):
+        device_key = 'fake-device-key'
+        provider = 'fake-provider'
+
+        lb_id = self.add_lbaasv2_lb(provider)
+        drivers = self.lbaasv2_drivers(provider, device_key)
+
         status = self.run_cli('install', drivers=drivers)
 
         return {
@@ -333,3 +377,25 @@ class TestCLI(test_base.UnitTestBase):
         tenant_appliance = session.query(models.A10TenantAppliance).first()
 
         self.assertEqual(tenant_appliance.a10_appliance.device_key, device_key)
+
+    def test_migration_remove_orphaned_a10_slb_v2(self):
+        device_key = 'fake-device-key'
+        provider = 'fake-provider'
+
+        self.add_lbaasv2_lb(provider)
+        drivers = self.lbaasv2_drivers(provider, device_key)
+
+        self.run_cli('upgrade', '2024607c4f06', drivers=drivers)
+
+        session1 = self.Session()
+        session1.execute("DELETE FROM a10_slb_v2")
+        session1.commit()
+
+        status = self.run_cli('install', drivers=drivers)
+        self.assertEqual('UPGRADED', status['core'].status)
+        self.assertEqual('UPGRADED', status['lbaasv2'].status)
+
+        session = self.Session()
+        slbs = list(session.query(models.A10SLB))
+
+        self.assertEqual([], slbs)

--- a/a10_neutron_lbaas/tests/db/test_operations.py
+++ b/a10_neutron_lbaas/tests/db/test_operations.py
@@ -16,7 +16,8 @@ import mock
 
 import test_base
 
-import a10_neutron_lbaas.db.operations as db_operations
+from a10_neutron_lbaas.db import models
+from a10_neutron_lbaas.db import operations as db_operations
 
 
 class TestOperations(test_base.UnitTestBase):
@@ -47,3 +48,43 @@ class TestOperations(test_base.UnitTestBase):
         operations2.session.commit()
 
         self.assertNotEqual(appliance1.id, appliance2.id)
+
+    def test_delete_slb_v1_deletes_slb(self):
+        slb = models.default(
+            models.A10SLBV1,
+            vip_id='fake-vip-id',
+            a10_appliance_id='fake-a10-appliance-id'
+        )
+
+        operations1 = self.operations()
+        operations1.add(slb)
+        operations1.session.commit()
+
+        operations2 = self.operations()
+        operations2.delete_slb_v1(slb.vip_id)
+        operations2.session.commit()
+
+        session = self.open_session()
+        slbs = list(session.query(models.A10SLB))
+
+        self.assertEqual([], slbs)
+
+    def test_delete_slb_v2_deletes_slb(self):
+        slb = models.default(
+            models.A10SLBV2,
+            lbaas_loadbalancer_id='lbaas_loadbalancer_id',
+            a10_appliance_id='fake-a10-appliance-id'
+        )
+
+        operations1 = self.operations()
+        operations1.add(slb)
+        operations1.session.commit()
+
+        operations2 = self.operations()
+        operations2.delete_slb_v2(slb.lbaas_loadbalancer_id)
+        operations2.session.commit()
+
+        session = self.open_session()
+        slbs = list(session.query(models.A10SLB))
+
+        self.assertEqual([], slbs)


### PR DESCRIPTION
Delete the `a10_slb` records when deleting `a10_slb_v1` or `a10_slb_v2`. Migrations to clean up orphaned `a10_slb` records that no longer have their corresponding `a10_slb_v1` or `a10_slb_v2`.