### PR TITLE
Removed 'verbose' option that is duplicated in oslo

### DIFF
--- a/a10_neutron_lbaas/db/migration/cli.py
+++ b/a10_neutron_lbaas/db/migration/cli.py
@@ -52,6 +52,16 @@ try:
 except cfg.DuplicateOptError:
     pass
 
+# There's an existing verbose option.
+# It conflicts with --verbose
+# It's deprecated, so we can't just use it instead.
+# Kill it.
+try:
+    CONF.unregister_opt(CONF._opts['verbose']['opt'])
+except Exception:
+    # With fire!
+    pass
+
 
 def do_alembic_command(config, cmd, *args, **kwargs):
     try:


### PR DESCRIPTION
This fixes a problem in `a10-neutron-lbaas-db-manage` where a duplicate option already registered in oslo was causing the migration tool to crash.