### PR TITLE
Use launch device per tenant as the default scheduler.

### DIFF
--- a/a10_neutron_lbaas/a10_openstack_lb.py
+++ b/a10_neutron_lbaas/a10_openstack_lb.py
@@ -82,10 +82,7 @@ class A10OpenstackLBBase(object):
 
         if scheduling_hooks_class is None:
             scheduling_hooks_class = (
-                # TODO(mdurrant) - Change this back to launch_device_per_tenant
-                # scheduling_hooks.launch_device_per_tenant
-                scheduling_hooks.existing_device_per_tenant
-
+                scheduling_hooks.launch_device_per_tenant
                 if plumbing_hooks_class is None else
                 scheduling_hooks.plumbing_hooks_device_per_tenant(plumbing_hooks)
             )

--- a/a10_neutron_lbaas/tests/db/test_a10_context.py
+++ b/a10_neutron_lbaas/tests/db/test_a10_context.py
@@ -20,6 +20,7 @@ import test_base
 
 import a10_neutron_lbaas.a10_context as a10_context
 import a10_neutron_lbaas.db.models as models
+import a10_neutron_lbaas.instance_manager as instance_manager
 
 
 class TestA10Context(test_a10_openstack_lb.SetupA10OpenstackLBBase, test_base.UnitTestBase):
@@ -50,8 +51,22 @@ class TestA10Context(test_a10_openstack_lb.SetupA10OpenstackLBBase, test_base.Un
     def test_inventory_find(self):
         """Test inventory and scheduling hooks in their almost-real environment"""
 
-        with self.a10_context:
-            appliance = self.a10_context.inventory.find(self.a10_context.openstack_lbaas_obj)
+        # We really just want to patch glance, but oslo library loading is non-standard.
+        mock_glance_client = mock.MagicMock()
+        mock_glance_client.images.list.return_value = []
+
+        InstanceManager = instance_manager.InstanceManager
+        with mock.patch(
+            'a10_neutron_lbaas.instance_manager.InstanceManager'
+        ) as mock_instance_manager:
+
+            mock_instance_manager.side_effect = lambda *args, **kwargs: InstanceManager(
+                *args,
+                glance_api=mock_glance_client,
+                **kwargs)
+
+            with self.a10_context:
+                appliance = self.a10_context.inventory.find(self.a10_context.openstack_lbaas_obj)
 
         session = self.a10_context.db_operations.session
         session.commit()

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ deps = -egit+https://git.openstack.org/openstack/neutron@465fb37118abfc047903923
        -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
 commands =
-  nosetests --with-noseexclude --exclude-dir=a10_neutron_lbaas/dashboard/
+  nosetests {posargs} --with-noseexclude --exclude-dir=a10_neutron_lbaas/dashboard/
 
 [testenv:pep8]
 commands =


### PR DESCRIPTION
Launch device per tenant wasn't the default scheduler because the
unit tests weren't passing due to the glance_client library not
loading correctly in tests. Mock the glance client to avoid tripping
on oslo trying to complete loading the library.

Fixes #207