### PR TITLE
Require alembic>=0.8.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 acos_client>=1.2.6
+alembic>=0.8.0


### PR DESCRIPTION
The migration cli imports `EnvironmentContext` from `alembic.runtime.environment`. According to the [bitbucket alembic history](https://bitbucket.org/zzzeek/alembic/commits/0e43247da4cfd2d829ee4b350e336364cb8a7ec1) it didn't exist before alembic 0.8.0.

Fixes #214