### PR TITLE
Simpler database upgrades

### DIFF
--- a/a10_neutron_lbaas/db/migration/alembic_migrations/lbaasv1/5a960cad849b_populate_vip_tenant_applianaces.py
+++ b/a10_neutron_lbaas/db/migration/alembic_migrations/lbaasv1/5a960cad849b_populate_vip_tenant_applianaces.py
@@ -35,9 +35,12 @@ import neutron.plugins.common.constants as constants
 
 
 def upgrade():
-    for provider, driver in context.config.drivers[constants.LOADBALANCER][0].items():
-        if hasattr(driver, 'a10') and isinstance(driver.a10, A10OpenstackLBV1):
-            upgrade_driver(provider, driver.a10)
+    conn = op.get_bind()
+    vips = conn.execute('SELECT count(*) from vips').scalar()
+    if vips:
+        for provider, driver in context.config.drivers[constants.LOADBALANCER][0].items():
+            if hasattr(driver, 'a10') and isinstance(driver.a10, A10OpenstackLBV1):
+                upgrade_driver(provider, driver.a10)
 
 
 def upgrade_driver(provider, a10):

--- a/a10_neutron_lbaas/db/migration/alembic_migrations/lbaasv2/2024607c4f06_populate_loadbalancer_tenant_applianaces.py
+++ b/a10_neutron_lbaas/db/migration/alembic_migrations/lbaasv2/2024607c4f06_populate_loadbalancer_tenant_applianaces.py
@@ -35,9 +35,12 @@ import neutron.plugins.common.constants as constants
 
 
 def upgrade():
-    for provider, driver in context.config.drivers[constants.LOADBALANCERV2][0].items():
-        if hasattr(driver, 'a10') and isinstance(driver.a10, A10OpenstackLBV2):
-            upgrade_driver(provider, driver.a10)
+    conn = op.get_bind()
+    lbs = conn.execute('SELECT count(*) from lbaas_loadbalancers').scalar()
+    if lbs:
+        for provider, driver in context.config.drivers[constants.LOADBALANCERV2][0].items():
+            if hasattr(driver, 'a10') and isinstance(driver.a10, A10OpenstackLBV2):
+                upgrade_driver(provider, driver.a10)
 
 
 def upgrade_driver(provider, a10):

--- a/a10_neutron_lbaas/tests/db/migration/test_cli.py
+++ b/a10_neutron_lbaas/tests/db/migration/test_cli.py
@@ -78,14 +78,14 @@ class TestCLI(test_base.UnitTestBase):
 
         self.assertEqual('UPGRADED', status['core'].status)
         self.assertEqual('UPGRADED', status['lbaasv1'].status)
-        self.assertEqual('ERROR', status['lbaasv2'].status)
+        self.assertEqual('UPGRADED', status['lbaasv2'].status)
 
     def test_install_lbaasv2(self):
         drivers = {'LOADBALANCERV2': mock.MagicMock()}
         status = self.run_cli('install', drivers=drivers)
 
         self.assertEqual('UPGRADED', status['core'].status)
-        self.assertEqual('ERROR', status['lbaasv1'].status)
+        self.assertEqual('UPGRADED', status['lbaasv1'].status)
         self.assertEqual('UPGRADED', status['lbaasv2'].status)
 
     def test_install_schema_matches_model_schema(self):


### PR DESCRIPTION
Only run the migrations to add device associations when there are existing vips or loadbalancers.
Makes both the lbaasv1 and lbaasv2 migrations succeed even if that version driver isn't installed.