### PR TITLE
Memory Write implementation for AXAPI v21/v30

### DIFF
--- a/a10_neutron_lbaas/a10_context.py
+++ b/a10_neutron_lbaas/a10_context.py
@@ -31,6 +31,7 @@ class A10Context(object):
         self.openstack_lbaas_obj = openstack_lbaas_obj
         self.device_name = kwargs.get('device_name', None)
         LOG.debug("A10Context obj=%s", openstack_lbaas_obj)
+        self.partition_name = None
 
     def __enter__(self):
         self.get_tenant_id()
@@ -69,7 +70,8 @@ class A10Context(object):
 
         if name == 'shared':
             return
-
+        else:
+            self.partition_name = name
         try:
             self.client.system.partition.active(name)
             return
@@ -86,7 +88,10 @@ class A10WriteContext(A10Context):
     def __exit__(self, exc_type, exc_value, traceback):
         if exc_type is None and self.device_cfg.get('write_memory', True):
             try:
-                self.client.system.action.write_active()
+                # AXAPI 2.1 is broken and does not correctly write tenant partitions.
+                shared_partition = self.device_cfg.get("shared_partition", "shared")
+                self.client.system.action.write_active(self.partition_name, shared_partition)
+
             except acos_errors.InvalidSessionID:
                 pass
 

--- a/a10_neutron_lbaas/a10_context.py
+++ b/a10_neutron_lbaas/a10_context.py
@@ -90,7 +90,7 @@ class A10WriteContext(A10Context):
             try:
                 # AXAPI 2.1 is broken and does not correctly write tenant partitions.
                 shared_partition = self.device_cfg.get("shared_partition", "shared")
-                self.client.system.action.write_active(self.partition_name, shared_partition)
+                self.client.system.action.write_active([self.partition_name, shared_partition])
 
             except acos_errors.InvalidSessionID:
                 pass

--- a/a10_neutron_lbaas/a10_context.py
+++ b/a10_neutron_lbaas/a10_context.py
@@ -31,7 +31,7 @@ class A10Context(object):
         self.openstack_lbaas_obj = openstack_lbaas_obj
         self.device_name = kwargs.get('device_name', None)
         LOG.debug("A10Context obj=%s", openstack_lbaas_obj)
-        self.partition_name = None
+        self.partition_name = "shared"
 
     def __enter__(self):
         self.get_tenant_id()

--- a/a10_neutron_lbaas/a10_context.py
+++ b/a10_neutron_lbaas/a10_context.py
@@ -67,11 +67,11 @@ class A10Context(object):
             name = self.tenant_id[0:13]
 
         # If we are not using appliance partitions, we are done.
-
         if name == 'shared':
             return
-        else:
-            self.partition_name = name
+
+        self.partition_name = name
+
         try:
             self.client.system.partition.active(name)
             return
@@ -88,8 +88,7 @@ class A10WriteContext(A10Context):
     def __exit__(self, exc_type, exc_value, traceback):
         if exc_type is None and self.device_cfg.get('write_memory', True):
             try:
-                shared_partition = self.device_cfg.get("shared_partition", "shared")
-                self.client.system.action.write_active([self.partition_name, shared_partition])
+                self.client.system.action.write_active(self.partition_name)
 
             except acos_errors.InvalidSessionID:
                 pass

--- a/a10_neutron_lbaas/a10_context.py
+++ b/a10_neutron_lbaas/a10_context.py
@@ -88,7 +88,6 @@ class A10WriteContext(A10Context):
     def __exit__(self, exc_type, exc_value, traceback):
         if exc_type is None and self.device_cfg.get('write_memory', True):
             try:
-                # AXAPI 2.1 is broken and does not correctly write tenant partitions.
                 shared_partition = self.device_cfg.get("shared_partition", "shared")
                 self.client.system.action.write_active([self.partition_name, shared_partition])
 

--- a/a10_neutron_lbaas/a10_context.py
+++ b/a10_neutron_lbaas/a10_context.py
@@ -86,7 +86,7 @@ class A10WriteContext(A10Context):
     def __exit__(self, exc_type, exc_value, traceback):
         if exc_type is None and self.device_cfg.get('write_memory', True):
             try:
-                self.client.system.action.write_memory()
+                self.client.system.action.write_active()
             except acos_errors.InvalidSessionID:
                 pass
 

--- a/a10_neutron_lbaas/a10_context.py
+++ b/a10_neutron_lbaas/a10_context.py
@@ -88,7 +88,7 @@ class A10WriteContext(A10Context):
     def __exit__(self, exc_type, exc_value, traceback):
         if exc_type is None and self.device_cfg.get('write_memory', True):
             try:
-                self.client.system.action.write_active(self.partition_name)
+                self.client.system.action.activate_and_write(self.partition_name)
 
             except acos_errors.InvalidSessionID:
                 pass

--- a/a10_neutron_lbaas/tests/unit/v1/test_a10_context.py
+++ b/a10_neutron_lbaas/tests/unit/v1/test_a10_context.py
@@ -46,7 +46,7 @@ class TestA10Context(test_base.UnitTestBase):
             self.empty_close_mocks()
 
     def _set_api_version(self, api_version="2.1"):
-        for k, v in self.a.config.devices.items():
+        for k, v in self.a.config.get("devices").items():
             v['api_version'] = api_version
 
     def test_write_v21(self):

--- a/a10_neutron_lbaas/tests/unit/v1/test_a10_context.py
+++ b/a10_neutron_lbaas/tests/unit/v1/test_a10_context.py
@@ -164,11 +164,11 @@ class TestA10ContextADP(TestA10Context):
         self._set_api_version("2.1")
         with a10.A10WriteContext(self.handler, self.ctx, self.m) as c:
             c
-        self.a.last_client.system.action.write_active.assert_called_with("faketen1", "shared")
+        self.a.last_client.system.action.write_active.assert_called_with(["faketen1", "shared"])
         self.a.last_client.session.close.assert_called_with()
 
     def test_write_v30(self):
         with a10.A10WriteContext(self.handler, self.ctx, self.m) as c:
             c
-        self.a.last_client.system.action.write_active.assert_called_with(mock.ANY, mock.ANY)
+        self.a.last_client.system.action.write_active.assert_called_with(mock.ANY)
         self.a.last_client.session.close.assert_called_with()

--- a/a10_neutron_lbaas/tests/unit/v1/test_a10_context.py
+++ b/a10_neutron_lbaas/tests/unit/v1/test_a10_context.py
@@ -164,12 +164,12 @@ class TestA10ContextADP(TestA10Context):
         self._set_api_version("2.1")
         with a10.A10WriteContext(self.handler, self.ctx, self.m) as c:
             c
-        self.a.last_client.system.action.write_active.assert_called_with(
-            "faketen1")
+        self.a.last_client.system.action.activate_and_write.assert_called_with(
+            mock.ANY)
         self.a.last_client.session.close.assert_called_with()
 
     def test_write_v30(self):
         with a10.A10WriteContext(self.handler, self.ctx, self.m) as c:
             c
-        self.a.last_client.system.action.write_active.assert_called_with(mock.ANY)
+        self.a.last_client.system.action.activate_and_write.assert_called_with(mock.ANY)
         self.a.last_client.session.close.assert_called_with()

--- a/a10_neutron_lbaas/tests/unit/v1/test_a10_context.py
+++ b/a10_neutron_lbaas/tests/unit/v1/test_a10_context.py
@@ -173,3 +173,13 @@ class TestA10ContextADP(TestA10Context):
             c
         self.a.last_client.system.action.activate_and_write.assert_called_with(mock.ANY)
         self.a.last_client.session.close.assert_called_with()
+
+    def test_write_v21_deleted_partition(self):
+        self._set_api_version("2.1")
+
+        with a10.A10WriteContext(self.handler, self.ctx, self.m) as c:
+            c
+            c.partition_name = None
+
+        self.a.last_client.system.action.activate_and_write.assert_called_with(None)
+        self.a.last_client.session.close.assert_called_with()

--- a/a10_neutron_lbaas/tests/unit/v1/test_a10_context.py
+++ b/a10_neutron_lbaas/tests/unit/v1/test_a10_context.py
@@ -165,7 +165,7 @@ class TestA10ContextADP(TestA10Context):
         with a10.A10WriteContext(self.handler, self.ctx, self.m) as c:
             c
         self.a.last_client.system.action.write_active.assert_called_with(
-            ["faketen1", "shared"])
+            "faketen1")
         self.a.last_client.session.close.assert_called_with()
 
     def test_write_v30(self):

--- a/a10_neutron_lbaas/tests/unit/v1/test_a10_context.py
+++ b/a10_neutron_lbaas/tests/unit/v1/test_a10_context.py
@@ -53,7 +53,7 @@ class TestA10Context(test_base.UnitTestBase):
         self._set_api_version()
         with a10.A10WriteContext(self.handler, self.ctx, self.m) as c:
             c
-        self.a.last_client.system.action.write_active.assert_called(None, "shared")
+        self.a.last_client.system.action.activate_and_write.assert_called(None, "shared")
         self.a.last_client.session.close.assert_called_with()
 
     def test_write_v30(self):

--- a/a10_neutron_lbaas/tests/unit/v1/test_a10_context.py
+++ b/a10_neutron_lbaas/tests/unit/v1/test_a10_context.py
@@ -183,3 +183,13 @@ class TestA10ContextADP(TestA10Context):
 
         self.a.last_client.system.action.activate_and_write.assert_called_with(None)
         self.a.last_client.session.close.assert_called_with()
+
+    def test_write_v21_partition(self):
+        self._set_api_version("2.1")
+        expected = "part1"
+        with a10.A10WriteContext(self.handler, self.ctx, self.m) as c:
+            c
+            c.partition_name = expected
+
+        self.a.last_client.system.action.activate_and_write.assert_called_with(expected)
+        self.a.last_client.session.close.assert_called_with()

--- a/a10_neutron_lbaas/tests/unit/v1/test_a10_context.py
+++ b/a10_neutron_lbaas/tests/unit/v1/test_a10_context.py
@@ -164,7 +164,8 @@ class TestA10ContextADP(TestA10Context):
         self._set_api_version("2.1")
         with a10.A10WriteContext(self.handler, self.ctx, self.m) as c:
             c
-        self.a.last_client.system.action.write_active.assert_called_with(["faketen1", "shared"])
+        self.a.last_client.system.action.write_active.assert_called_with(
+            ["faketen1", "shared"])
         self.a.last_client.session.close.assert_called_with()
 
     def test_write_v30(self):

--- a/a10_neutron_lbaas/tests/unit/v1/test_a10_context.py
+++ b/a10_neutron_lbaas/tests/unit/v1/test_a10_context.py
@@ -47,7 +47,7 @@ class TestA10Context(test_base.UnitTestBase):
     def test_write(self):
         with a10.A10WriteContext(self.handler, self.ctx, self.m) as c:
             c
-        self.a.last_client.system.action.write_memory.assert_called_with()
+        self.a.last_client.system.action.write_active.assert_called_with()
         self.a.last_client.session.close.assert_called_with()
 
     def test_ha(self):

--- a/a10_neutron_lbaas/tests/unit/v1/test_a10_context.py
+++ b/a10_neutron_lbaas/tests/unit/v1/test_a10_context.py
@@ -14,6 +14,7 @@
 
 import a10_neutron_lbaas.v1.v1_context as a10
 
+import mock
 import test_base
 
 
@@ -44,10 +45,22 @@ class TestA10Context(test_base.UnitTestBase):
         except FakeException:
             self.empty_close_mocks()
 
-    def test_write(self):
+    def _set_api_version(self, api_version="2.1"):
+        for k, v in self.a.config.devices.items():
+            v['api_version'] = api_version
+
+    def test_write_v21(self):
+        self._set_api_version()
         with a10.A10WriteContext(self.handler, self.ctx, self.m) as c:
             c
-        self.a.last_client.system.action.write_active.assert_called_with()
+        self.a.last_client.system.action.write_active.assert_called(None, "shared")
+        self.a.last_client.session.close.assert_called_with()
+
+    def test_write_v30(self):
+        self._set_api_version("3.0")
+        with a10.A10WriteContext(self.handler, self.ctx, self.m) as c:
+            c
+        self.a.last_client.system.action.write_memory.assert_called()
         self.a.last_client.session.close.assert_called_with()
 
     def test_ha(self):
@@ -145,4 +158,17 @@ class TestA10ContextADP(TestA10Context):
         self.print_mocks()
         self.assertEqual(0, len(self.a.openstack_driver.mock_calls))
         self.assertEqual(2, len(self.a.last_client.mock_calls))
+        self.a.last_client.session.close.assert_called_with()
+
+    def test_write_v21(self):
+        self._set_api_version("2.1")
+        with a10.A10WriteContext(self.handler, self.ctx, self.m) as c:
+            c
+        self.a.last_client.system.action.write_active.assert_called_with("faketen1", "shared")
+        self.a.last_client.session.close.assert_called_with()
+
+    def test_write_v30(self):
+        with a10.A10WriteContext(self.handler, self.ctx, self.m) as c:
+            c
+        self.a.last_client.system.action.write_active.assert_called_with(mock.ANY, mock.ANY)
         self.a.last_client.session.close.assert_called_with()

--- a/a10_neutron_lbaas/tests/unit/v2/test_a10_context.py
+++ b/a10_neutron_lbaas/tests/unit/v2/test_a10_context.py
@@ -28,7 +28,7 @@ class TestA10Context(test_base.UnitTestBase):
             "tenant_id": "admin"
         }
 
-        return mock.Mock(get_admin_context=mock.Mock(return_value=admin_context))
+        return mock.Mock(is_admin=False, get_admin_context=mock.Mock(return_value=admin_context))
 
     def setUp(self):
         super(TestA10Context, self).setUp()
@@ -54,7 +54,7 @@ class TestA10Context(test_base.UnitTestBase):
     def test_write(self):
         with a10.A10WriteContext(self.handler, self.ctx, self.m, device_name='ax-write') as c:
             c
-        self.a.last_client.system.action.write_active.assert_called_with()
+        self.a.last_client.system.action.write_memory.assert_called()
         self.a.last_client.session.close.assert_called_with()
 
     def test_write_no_write(self):
@@ -152,4 +152,18 @@ class TestA10ContextADP(TestA10Context):
         self.print_mocks()
         self.assertEqual(0, len(self.a.openstack_driver.mock_calls))
         self.assertEqual(2, len(self.a.last_client.mock_calls))
+        self.a.last_client.session.close.assert_called_with()
+
+    def test_write_v21(self):
+        self._set_api_version("2.1")
+        with a10.A10WriteContext(self.handler, self.ctx, self.m) as c:
+            c
+        self.a.last_client.system.action.write_active.assert_called_with("get-off-my-la", "shared")
+        self.a.last_client.session.close.assert_called_with()
+
+    def test_write_v30(self):
+        self._set_api_version("3.0")
+        with a10.A10WriteContext(self.handler, self.ctx, self.m) as c:
+            c
+        self.a.last_client.system.action.write_memory.assert_called()
         self.a.last_client.session.close.assert_called_with()

--- a/a10_neutron_lbaas/tests/unit/v2/test_a10_context.py
+++ b/a10_neutron_lbaas/tests/unit/v2/test_a10_context.py
@@ -28,7 +28,7 @@ class TestA10Context(test_base.UnitTestBase):
             "tenant_id": "admin"
         }
 
-        return mock.Mock(is_admin=False, get_admin_context=mock.Mock(return_value=admin_context))
+        return mock.Mock(get_admin_context=mock.Mock(return_value=admin_context))
 
     def setUp(self):
         super(TestA10Context, self).setUp()
@@ -158,7 +158,8 @@ class TestA10ContextADP(TestA10Context):
         self._set_api_version("2.1")
         with a10.A10WriteContext(self.handler, self.ctx, self.m) as c:
             c
-        self.a.last_client.system.action.write_active.assert_called_with(["get-off-my-la", "shared"])
+        self.a.last_client.system.action.write_active.assert_called_with(["get-off-my-la",
+                                                                          "shared"])
         self.a.last_client.session.close.assert_called_with()
 
     def test_write_v30(self):

--- a/a10_neutron_lbaas/tests/unit/v2/test_a10_context.py
+++ b/a10_neutron_lbaas/tests/unit/v2/test_a10_context.py
@@ -158,7 +158,7 @@ class TestA10ContextADP(TestA10Context):
         self._set_api_version("2.1")
         with a10.A10WriteContext(self.handler, self.ctx, self.m) as c:
             c
-        self.a.last_client.system.action.write_active.assert_called_with("get-off-my-la", "shared")
+        self.a.last_client.system.action.write_active.assert_called_with(["get-off-my-la", "shared"])
         self.a.last_client.session.close.assert_called_with()
 
     def test_write_v30(self):

--- a/a10_neutron_lbaas/tests/unit/v2/test_a10_context.py
+++ b/a10_neutron_lbaas/tests/unit/v2/test_a10_context.py
@@ -153,17 +153,3 @@ class TestA10ContextADP(TestA10Context):
         self.assertEqual(0, len(self.a.openstack_driver.mock_calls))
         self.assertEqual(2, len(self.a.last_client.mock_calls))
         self.a.last_client.session.close.assert_called_with()
-
-    def test_write_v21(self):
-        self._set_api_version("2.1")
-        with a10.A10WriteContext(self.handler, self.ctx, self.m) as c:
-            c
-        self.a.last_client.system.action.write_active.assert_called_with("get-off-my-la")
-        self.a.last_client.session.close.assert_called_with()
-
-    def test_write_v30(self):
-        self._set_api_version("3.0")
-        with a10.A10WriteContext(self.handler, self.ctx, self.m) as c:
-            c
-        self.a.last_client.system.action.write_memory.assert_called()
-        self.a.last_client.session.close.assert_called_with()

--- a/a10_neutron_lbaas/tests/unit/v2/test_a10_context.py
+++ b/a10_neutron_lbaas/tests/unit/v2/test_a10_context.py
@@ -158,8 +158,7 @@ class TestA10ContextADP(TestA10Context):
         self._set_api_version("2.1")
         with a10.A10WriteContext(self.handler, self.ctx, self.m) as c:
             c
-        self.a.last_client.system.action.write_active.assert_called_with(["get-off-my-la",
-                                                                          "shared"])
+        self.a.last_client.system.action.write_active.assert_called_with("get-off-my-la")
         self.a.last_client.session.close.assert_called_with()
 
     def test_write_v30(self):

--- a/a10_neutron_lbaas/tests/unit/v2/test_a10_context.py
+++ b/a10_neutron_lbaas/tests/unit/v2/test_a10_context.py
@@ -54,7 +54,7 @@ class TestA10Context(test_base.UnitTestBase):
     def test_write(self):
         with a10.A10WriteContext(self.handler, self.ctx, self.m, device_name='ax-write') as c:
             c
-        self.a.last_client.system.action.write_memory.assert_called_with()
+        self.a.last_client.system.action.write_active.assert_called_with()
         self.a.last_client.session.close.assert_called_with()
 
     def test_write_no_write(self):


### PR DESCRIPTION
Functional memory write implementation for both AXAPI versions.  Ensures active and alternate shared partitions are written.