### PR TITLE
Configurable certificate manager

### DIFF
--- a/a10_neutron_lbaas/v2/neutron_ops.py
+++ b/a10_neutron_lbaas/v2/neutron_ops.py
@@ -15,7 +15,6 @@ try:
 except ImportError:
     pass
 try:
-    import neutron_lbaas.common.cert_manager.barbican_cert_manager as bcm
     from neutron_lbaas.db.loadbalancer import models as lb_db
 except ImportError:
     # v2 does not exist before Kilo
@@ -51,7 +50,8 @@ class NeutronOpsV2(object):
         return self.plugin.db.get_pool(context, pool_id)
 
     def bcm_factory(self):
-        return bcm.CertManager()
+        from neutron_lbaas.services.loadbalancer.plugin import CERT_MANAGER_PLUGIN
+        return CERT_MANAGER_PLUGIN.CertManager()
 
     def vip_get(self, context, vip_id):
         return self.plugin.db.get_vip(context, vip_id)


### PR DESCRIPTION
SSL/TLS supports arbitrary certificate managers instead of just barbican

-----

 * ssl templates are named after the listener
 * Pass client ssl template to acos_client
 * Clean up automatically created SSL templates