### PR TITLE
Refactored fake obj dicts into classes in separate module (V1)

### DIFF
--- a/a10_neutron_lbaas/tests/unit/v1/fake_objs.py
+++ b/a10_neutron_lbaas/tests/unit/v1/fake_objs.py
@@ -1,0 +1,82 @@
+# Copyright 2014, Doug Wiegley (dougwig), A10 Networks
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+
+class FakeModel(dict, object):
+    def __getitem__(self, key, default=None):
+        attr = getattr(self, key, default)
+        return attr
+
+    def get(self, key, default=None):
+        return getattr(self, key, default)
+
+
+class FakeVIP(FakeModel):
+    def __init__(self, pers="", vip_id="id1"):
+        super(FakeVIP, self).__init__()
+        self.tenant_id = 'ten1'
+        self.id = vip_id
+        self.protocol = 'HTTP'
+        self.admin_state_up = True
+        self.address = '1.1.1.1'
+        self.protocol_port = '80'
+        self.pool_id = 'pool1'
+        self.subnet_id = 'subnet1'
+        self.root_loadbalancer = self
+        if pers:
+            self.session_persistence = {'type': pers}
+
+
+class FakeHM(FakeModel):
+    def __init__(self, type=None):
+        super(FakeHM, self).__init__()
+        self.id = "hm01"
+        self.name = "hm01"
+        self.tenant_id = 'tenv1'
+        self.type = type
+        self.delay = '5'
+        self.timeout = 5
+        self.max_retries = '5'
+        self.pools = []
+        self.root_loadbalancer = FakeVIP()
+        if type in ['HTTP', 'HTTPS']:
+            self.http_method = 'GET'
+            self.url_path = '/'
+            self.expected_codes = '200'
+
+    def copy(self):
+        return self
+
+
+class FakePool(FakeModel):
+    def __init__(self, protocol='TCP', method='ROUND_ROBIN'):
+        super(FakePool, self).__init__()
+        self.id = 'id1'
+        self.tenant_id = 'ten1'
+        self.protocol = protocol
+        self.lb_method = method
+        self.members = []
+        self.root_loadbalancer = FakeVIP()
+
+
+class FakeMember(FakeModel):
+    def __init__(self, admin_state_up=True, pool_id='pool1'):
+        super(FakeMember, self).__init__()
+        self.address = '1.1.1.1'
+        self.id = 'id1'
+        self.tenant_id = 'ten1'
+        self.admin_state_up = admin_state_up
+        self.pool_id = pool_id
+        self.protocol_port = '80'
+        self.root_loadbalancer = FakeVIP()

--- a/a10_neutron_lbaas/tests/unit/v1/test_base.py
+++ b/a10_neutron_lbaas/tests/unit/v1/test_base.py
@@ -15,32 +15,6 @@
 import a10_neutron_lbaas.tests.unit.test_base as test_base
 
 
-class FakeModel(dict, object):
-    def __getitem__(self, key, default=None):
-        attr = getattr(self, key, default)
-        return attr
-
-    def get(self, key, default=None):
-        return getattr(self, key, default)
-
-    # def copy(self):
-    #     import copy
-    #     return copy.deepcopy(self)
-
-
-class FakeHM(FakeModel):
-    def __init__(self, id="hm01", name="hm01"):
-        self.id = id
-        self.name = name
-        self.pools = []
-
-
-class FakePool(FakeModel):
-    def __init__(self, id="p01", name="p01"):
-        self.id = id
-        self.name = name
-
-
 class UnitTestBase(test_base.UnitTestBase):
 
     def __init__(self, *args):

--- a/a10_neutron_lbaas/tests/unit/v1/test_handler_hm.py
+++ b/a10_neutron_lbaas/tests/unit/v1/test_handler_hm.py
@@ -12,7 +12,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-
+import fake_objs
 import test_base
 
 
@@ -21,90 +21,73 @@ class TestHM(test_base.UnitTestBase):
     def assert_hm(self, mon_type, method, url, expect_code):
         self.print_mocks()
         self.a.last_client.slb.hm.create.assert_called_with(
-            'abcdef', mon_type, '5', 5, '5',
+            'hm01', mon_type, '5', 5, '5',
             url=url, method=method, expect_code=expect_code,
             axapi_args={})
 
-    def fake_hm(self, type):
-        hm = {
-            'tenant_id': 'tenv1',
-            'id': 'abcdef',
-            'name': 'abcdef',
-            'type': type,
-            'delay': '5',
-            'timeout': 5,
-            'max_retries': '5',
-            'pools': [],
-        }
-        if type in ['HTTP', 'HTTPS']:
-            hm['http_method'] = 'GET'
-            hm['url_path'] = '/'
-            hm['expected_codes'] = '200'
-        return hm.copy()
-
     def test_create_ping(self):
-        self.a.hm.create(None, self.fake_hm('PING'), 'p01')
+        self.a.hm.create(None, fake_objs.FakeHM('PING'), 'p01')
         self.assert_hm(self.a.last_client.slb.hm.ICMP, None, None, None)
         pool_name = self.a.hm._pool_name(None, 'p01')
         self.a.last_client.slb.service_group.update.assert_called_with(
-            pool_name, health_monitor='abcdef')
+            pool_name, health_monitor='hm01')
 
     def test_create_tcp(self):
-        hm = self.fake_hm('TCP')
-        hm['pools'] = [{'pool_id': 'p02'}, {'pool_id': 'p01'}]
+        hm = fake_objs.FakeHM('TCP')
+        hm.pools = [{'pool_id': 'p02'}, {'pool_id': 'p01'}]
         self.a.hm.create(None, hm, 'p01')
         self.assert_hm(self.a.last_client.slb.hm.TCP, None, None, None)
         pool_name = self.a.hm._pool_name(None, 'p02')
         self.a.last_client.slb.service_group.update.assert_called_with(
-            pool_name, health_monitor='abcdef')
+            pool_name, health_monitor='hm01')
 
     def test_create_http(self):
-        self.a.hm.create(None, self.fake_hm('HTTP'), 'p01')
+        self.a.hm.create(None, fake_objs.FakeHM('HTTP'), 'p01')
         self.assert_hm(self.a.last_client.slb.hm.HTTP, 'GET', '/', '200')
         pool_name = self.a.hm._pool_name(None, 'p01')
         self.a.last_client.slb.service_group.update.assert_called_with(
-            pool_name, health_monitor='abcdef')
+            pool_name, health_monitor='hm01')
 
     def test_create_https(self):
-        self.a.hm.create(None, self.fake_hm('HTTPS'), 'p01')
+        self.a.hm.create(None, fake_objs.FakeHM('HTTPS'), 'p01')
         self.assert_hm(self.a.last_client.slb.hm.HTTPS, 'GET', '/', '200')
         pool_name = self.a.hm._pool_name(None, 'p01')
         self.a.last_client.slb.service_group.update.assert_called_with(
-            pool_name, health_monitor='abcdef')
+            pool_name, health_monitor='hm01')
 
     def test_update_tcp(self, m_old=None, m=None):
         if m_old is None:
-            m_old = self.fake_hm('TCP')
+            m_old = fake_objs.FakeHM('TCP')
         if m is None:
-            m = self.fake_hm('TCP')
-        m['delay'] = 20
+            m = fake_objs.FakeHM('TCP')
+        m.delay = 20
         self.a.hm.update(None, m_old, m, 'p01')
         self.a.last_client.slb.hm.update.assert_called_with(
-            'abcdef',
+            'hm01',
             self.a.last_client.slb.hm.TCP, 20, 5, '5',
             url=None, method=None, expect_code=None,
             axapi_args={})
 
     def test_delete(self):
-        expected = test_base.FakePool()
-        fakehm = test_base.FakeHM()
-        fakehm['tenant_id'] = 'tenv1'
-        fakehm['id'] = 'fedcba'
+        expected = fake_objs.FakePool()
+        fakehm = fake_objs.FakeHM('HTTP')
+        fakehm.tenant_id = 'tenv1'
+        fakehm.id = 'fedcba'
         fakehm.pools.append(expected)
 
         self.a.hm.openstack_driver.plugin.get_pool.return_value = expected
         self.a.hm.openstack_driver._hm_binding_count.return_value = 1
 
         self.a.hm.delete(None, fakehm, 'p01')
-        self.a.last_client.slb.hm.delete.assert_called_with(fakehm["id"])
+        self.a.last_client.slb.hm.delete.assert_called_with(fakehm.id)
 
     def test_delete_updates_pool_health_monitor(self):
-        expected = test_base.FakePool()
-        fakehm = test_base.FakeHM()
-        fakehm['tenant_id'] = 'tenv1'
-        fakehm['id'] = 'fedcba'
-        fakehm['pools'] = []
-        fakehm['pools'].append(expected)
+        expected = fake_objs.FakePool()
+        fakehm = fake_objs.FakeHM('HTTP')
+        fakehm.tenant_id = 'tenv1'
+        fakehm.id = 'fedcba'
+        fakehm.pools = []
+        fakehm.pools.append(expected)
 
         self.a.hm.openstack_driver._pool_get_hm.return_value = fakehm
         self.a.hm.openstack_driver.plugin.get_pool.return_value = expected
@@ -117,25 +100,25 @@ class TestHM(test_base.UnitTestBase):
             pool_name, health_monitor='', health_check_disable=True)
 
     def test_dissociate_calls_service_group_update(self):
-        fake_pool = test_base.FakePool()
-        fake_hm = test_base.FakeHM()
-        fake_hm["id"] = "id1"
-        fake_hm["pools"] = []
-        fake_hm["pools"].append(fake_pool)
-        fake_hm['tenant_id'] = "tenv1"
+        fake_pool = fake_objs.FakePool()
+        fake_hm = fake_objs.FakeHM('HTTP')
+        fake_hm.id = "id1"
+        fake_hm.pools = []
+        fake_hm.pools.append(fake_pool)
+        fake_hm.tenant_id = "tenv1"
 
         self.a.hm.dissociate(self.a.last_client, None, fake_hm, fake_pool.id)
         self.a.last_client.slb.service_group.update.assert_called(
             fake_pool.id, health_monitor="", health_check_disable=True)
 
     def test_dissociate_calls_hm_delete(self):
-        fake_pool = test_base.FakePool()
-        fake_hm = test_base.FakeHM()
-        fake_pool["health_monitor_status"] = [{"monitor_id": fake_hm.id}]
-        fake_hm["id"] = "id1"
-        fake_hm["pools"] = []
-        fake_hm["pools"].append(fake_pool)
-        fake_hm['tenant_id'] = "tenv1"
+        fake_pool = fake_objs.FakePool()
+        fake_hm = fake_objs.FakeHM('HTTP')
+        fake_pool.health_monitor_status = [{"monitor_id": fake_hm.id}]
+        fake_hm.id = "id1"
+        fake_hm.pools = []
+        fake_hm.pools.append(fake_pool)
+        fake_hm.tenant_id = "tenv1"
 
         self.a.hm.dissociate(self.a.last_client, None, fake_hm, fake_pool.id)
         self.a.last_client.hm.service_group.delete.assert_called(self.a.hm._meta_name(fake_hm))

--- a/a10_neutron_lbaas/tests/unit/v1/test_handler_member.py
+++ b/a10_neutron_lbaas/tests/unit/v1/test_handler_member.py
@@ -1,4 +1,3 @@
-# Copyright 2014, Doug Wiegley (dougwig), A10 Networks
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
 #    not use this file except in compliance with the License. You may obtain
@@ -12,6 +11,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+import fake_objs
 import test_base
 
 
@@ -23,17 +23,6 @@ def return_two(*args):
     return 2
 
 
-def _fake_member(pool_id='pool1', admin_state_up=True):
-    return {
-        'address': '1.1.1.1',
-        'tenant_id': 'ten1',
-        'id': 'id1',
-        'admin_state_up': admin_state_up,
-        'pool_id': pool_id,
-        'protocol_port': '80',
-    }.copy()
-
-
 class TestMembers(test_base.UnitTestBase):
 
     def set_count_1(self):
@@ -43,27 +32,24 @@ class TestMembers(test_base.UnitTestBase):
         self.a.openstack_driver._member_count = return_two
 
     def test_get_ip(self):
-        m = self.fake_member()
+        m = fake_objs.FakeMember()
         self.a.member.neutron.member_get_ip(None, m, False)
         self.a.openstack_driver._member_get_ip.assert_called_with(
             None, m, False)
 
     def test_get_name(self):
-        m = self.fake_member()
+        m = fake_objs.FakeMember()
         z = self.a.member._get_name(m, '1.1.1.1')
         self.assertEqual(z, '_ten1_1_1_1_1_neutron')
 
     def test_count(self):
-        self.a.member.neutron.member_count(None, self.fake_member())
-
-    def fake_member(pool_id='pool1', admin_state_up=True):
-        return _fake_member(pool_id, admin_state_up)
+        self.a.member.neutron.member_count(None, fake_objs.FakeMember())
 
     def _test_create(self, admin_state_up=True, uuid_name=False):
         if uuid_name:
             old = self.a.config.get('member_name_use_uuid')
             self.a.config._config.member_name_use_uuid = True
-        m = self.fake_member(admin_state_up=admin_state_up)
+        m = fake_objs.FakeMember(admin_state_up=admin_state_up)
         ip = self.a.member.neutron.member_get_ip(None, m, True)
         if uuid_name:
             name = m['id']
@@ -96,7 +82,7 @@ class TestMembers(test_base.UnitTestBase):
         self._test_create(admin_state_up=False)
 
     def test_update_down(self):
-        m = self.fake_member(admin_state_up=False)
+        m = fake_objs.FakeMember(admin_state_up=False)
         ip = self.a.member.neutron.member_get_ip(None, m, True)
         name = self.a.member._get_name(m, ip)
         self.a.member.update(None, m, m)
@@ -108,7 +94,7 @@ class TestMembers(test_base.UnitTestBase):
             axapi_args={'member': {}})
 
     def test_delete(self):
-        m = self.fake_member()
+        m = fake_objs.FakeMember()
         ip = self.a.member.neutron.member_get_ip(None, m, True)
 
         self.set_count_1()
@@ -117,7 +103,7 @@ class TestMembers(test_base.UnitTestBase):
         self.a.last_client.slb.server.delete(ip)
 
     def test_delete_count_gt_one(self):
-        m = self.fake_member()
+        m = fake_objs.FakeMember()
         ip = self.a.member.neutron.member_get_ip(None, m, True)
         name = self.a.member._get_name(m, ip)
 

--- a/a10_neutron_lbaas/tests/unit/v1/test_handler_pool.py
+++ b/a10_neutron_lbaas/tests/unit/v1/test_handler_pool.py
@@ -12,35 +12,11 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+import fake_objs
 import test_base
-import test_handler_member
 
 
 class TestPools(test_base.UnitTestBase):
-    def fake_hm(self, type):
-        hm = {
-            'tenant_id': 'tenv1',
-            'id': 'abcdef',
-            'name': 'abcdef',
-            'type': type,
-            'delay': '5',
-            'timeout': 5,
-            'max_retries': '5',
-            'pools': [],
-        }
-        if type in ['HTTP', 'HTTPS']:
-            hm['http_method'] = 'GET'
-            hm['url_path'] = '/'
-            hm['expected_codes'] = '200'
-        return hm.copy()
-
-    def fake_pool(self, protocol, method):
-        return {
-            'tenant_id': 'ten1',
-            'id': 'id1',
-            'protocol': protocol,
-            'lb_method': method,
-        }.copy()
 
     def test_create(self):
         methods = {
@@ -61,7 +37,7 @@ class TestPools(test_base.UnitTestBase):
                 self.a.reset_mocks()
                 saw_exception = False
 
-                pool = self.fake_pool(p, m)
+                pool = fake_objs.FakePool(p, m)
                 self.a.pool.create(None, pool)
 
                 self.print_mocks()
@@ -74,8 +50,8 @@ class TestPools(test_base.UnitTestBase):
                     self.assertTrue(n >= 0)
 
     def test_update(self):
-        old_pool = self.fake_pool('TCP', 'LEAST_CONNECTIONS')
-        pool = self.fake_pool('TCP', 'ROUND_ROBIN')
+        old_pool = fake_objs.FakePool('TCP', 'LEAST_CONNECTIONS')
+        pool = fake_objs.FakePool('TCP', 'ROUND_ROBIN')
         self.a.pool.update(None, old_pool, pool)
         self.print_mocks()
         self.a.last_client.slb.service_group.update.assert_called()
@@ -85,10 +61,10 @@ class TestPools(test_base.UnitTestBase):
         self.print_mocks()
 
     def test_delete(self):
-        pool = self.fake_pool('TCP', 'LEAST_CONNECTIONS')
-        pool['members'] = [test_handler_member._fake_member()]
-        pool['health_monitors_status'] = [{'monitor_id': 'hm1', "pools": [pool]}]
-        self.a.pool.neutron.openstack_driver._pool_get_hm.return_value = test_base.FakeHM()
+        pool = fake_objs.FakePool('TCP', 'LEAST_CONNECTIONS')
+        pool.members = [fake_objs.FakeMember()]
+        pool.health_monitors_status = [{'monitor_id': 'hm1', "pools": [pool]}]
+        self.a.pool.neutron.openstack_driver._pool_get_hm.return_value = fake_objs.FakeHM()
 
         self._test_delete(pool)
 
@@ -96,11 +72,11 @@ class TestPools(test_base.UnitTestBase):
             assert_called_with(pool['id']))
 
     def test_delete_with_hm_dissociates_hm(self):
-        pool = self.fake_pool('TCP', 'LEAST_CONNECTIONS')
-        hm = self.fake_hm("TCP")
-        hm["pools"].append(self.fake_pool('TCP', 'LEAST_CONNECTIONS'))
-        pool['members'] = [test_handler_member._fake_member()]
-        pool['health_monitors_status'] = [{'monitor_id': 'hm1', "pools": [pool]}]
+        pool = fake_objs.FakePool('TCP', 'LEAST_CONNECTIONS')
+        hm = fake_objs.FakeHM("TCP")
+        hm.pools.append(fake_objs.FakePool('TCP', 'LEAST_CONNECTIONS'))
+        pool.members = [fake_objs.FakeMember()]
+        pool.health_monitors_status = [{'monitor_id': 'hm1', "pools": [pool]}]
 
         self.a.pool.neutron.openstack_driver._pool_get_hm.return_value = hm
 
@@ -111,26 +87,26 @@ class TestPools(test_base.UnitTestBase):
             health_check_disable=True)
 
     def test_delete_without_health_monitor(self):
-        pool = self.fake_pool('TCP', 'LEAST_CONNECTIONS')
-        pool['members'] = [test_handler_member._fake_member()]
-        pool['health_monitors_status'] = []
+        pool = fake_objs.FakePool('TCP', 'LEAST_CONNECTIONS')
+        pool.members = [fake_objs.FakePool()]
+        pool.health_monitors_status = []
         self._test_delete(pool)
         (self.a.last_client.slb.service_group.delete.
-            assert_called_with(pool['id']))
+            assert_called_with(pool.id))
 
     def test_delete_removes_monitor(self):
-        pool = self.fake_pool('TCP', 'LEAST_CONNECTIONS')
-        pool['members'] = [test_handler_member._fake_member()]
-        pool['health_monitors_status'] = [{'monitor_id': "hm1"}]
+        pool = fake_objs.FakePool('TCP', 'LEAST_CONNECTIONS')
+        pool.members = [fake_objs.FakeMember()]
+        pool.health_monitors_status = [{'monitor_id': "hm1"}]
         self.a.pool.delete(None, pool)
         self.a.last_client.slb.hm.delete.assert_called()
 
     def test_stats(self):
-        pool = self.fake_pool('TCP', 'LEAST_CONNECTIONS')
+        pool = fake_objs.FakePool('TCP', 'LEAST_CONNECTIONS')
         z = self.a.pool
         z.neutron.pool_get_tenant_id = lambda x, y: 'hello'
         z._get_vip_id = lambda x, y: '2.2.2.2'
-        z.stats(None, pool['id'])
+        z.stats(None, pool.id)
         self.print_mocks()
         s = str(self.a.last_client.mock_calls)
         self.assertTrue(s.index('slb.virtual_server.stats') >= 0)


### PR DESCRIPTION
As an a10-neutron-lbaas developer, I would like the fake objects to be within their own module so I can more effectively test future additions to a-n-l.