### PR TITLE
Support 'syn cookie' feature for vports.

### DIFF
--- a/a10_neutron_lbaas/etc/config.py
+++ b/a10_neutron_lbaas/etc/config.py
@@ -149,6 +149,9 @@ devices = {
     # Enable IP in IP on vports.
     #     "ipinip": False,
     #
+    # Enable syn cookie.
+    #     "syn_cookie": False,
+    #
     # Contains a list of hostnames or IP addresses that the driver will run
     # the 'ha sync' command against whenever a write operation occurs.
     #     "ha_sync_list": [],

--- a/a10_neutron_lbaas/etc/defaults.py
+++ b/a10_neutron_lbaas/etc/defaults.py
@@ -45,6 +45,7 @@ DEVICE_OPTIONAL_DEFAULTS = {
     "use_float": False,
     "default_virtual_server_vrid": None,
     "ipinip": False,
+    "syn_cookie": False,
     "ha_sync_list": [],
     "write_memory": True,
 

--- a/a10_neutron_lbaas/v1/handler_vip.py
+++ b/a10_neutron_lbaas/v1/handler_vip.py
@@ -97,6 +97,7 @@ class VipHandler(handler_base_v1.HandlerBaseV1):
                         status=status,
                         autosnat=c.device_cfg.get('autosnat'),
                         ipinip=c.device_cfg.get('ipinip'),
+                        syn_cookie=c.device_cfg.get('syn_cookie'),
                         axapi_body=vport)
                 except acos_errors.Exists:
                     pass
@@ -141,6 +142,7 @@ class VipHandler(handler_base_v1.HandlerBaseV1):
                 status=status,
                 autosnat=c.device_cfg.get('autosnat'),
                 ipinip=c.device_cfg.get('ipinip'),
+                syn_cookie=c.device_cfg.get('syn_cookie'),
                 axapi_body=vport_meta)
 
             self.hooks.after_vip_update(c, context, vip)

--- a/a10_neutron_lbaas/v2/handler_listener.py
+++ b/a10_neutron_lbaas/v2/handler_listener.py
@@ -104,6 +104,7 @@ class ListenerHandler(handler_base_v2.HandlerBaseV2):
                 status=status,
                 autosnat=c.device_cfg.get('autosnat'),
                 ipinip=c.device_cfg.get('ipinip'),
+                syn_cookie=c.device_cfg.get('syn_cookie'),
                 axapi_body=vport_meta,
                 **template_args)
         except acos_errors.Exists:


### PR DESCRIPTION
This patch enables to set 'syn cookie' flag on virtual ports.
Tested only with LBaaSv1 and use_database=False.
