### PR TITLE
WIP: Authorization from Horizon

### DIFF
--- a/a10_neutron_lbaas/db/migration/alembic_migrations/versions/2a280aba7701_create_orchestration.py
+++ b/a10_neutron_lbaas/db/migration/alembic_migrations/versions/2a280aba7701_create_orchestration.py
@@ -50,7 +50,7 @@ def upgrade():
         sa.Column('ipinip', sa.Boolean(), nullable=False),
         sa.Column('write_memory', sa.Boolean(), nullable=False),
 
-        sa.Column('nova_instance_id', sa.String(36), nullable=False),
+        sa.Column('nova_instance_id', sa.String(36), nullable=True),
         sa.Column('host', sa.String(255), nullable=False)
     )
     op.create_table(

--- a/a10_neutron_lbaas/neutron_ext/db/a10_device_instance.py
+++ b/a10_neutron_lbaas/neutron_ext/db/a10_device_instance.py
@@ -13,6 +13,7 @@
 #    under the License.
 
 import logging
+import uuid
 
 from a10_openstack_lib.resources import a10_device_instance as a10_device_instance_resources
 from neutron.db import common_db_mixin
@@ -22,7 +23,12 @@ from a10_neutron_lbaas.db import models
 from a10_neutron_lbaas.neutron_ext.common import resources
 from a10_neutron_lbaas.neutron_ext.extensions import a10DeviceInstance
 
+
 LOG = logging.getLogger(__name__)
+
+
+def _uuid_str():
+    return str(uuid.uuid4())
 
 
 class A10DeviceInstanceDbMixin(common_db_mixin.CommonDbMixin,
@@ -70,7 +76,7 @@ class A10DeviceInstanceDbMixin(common_db_mixin.CommonDbMixin,
 
         with context.session.begin(subtransactions=True):
             instance_record = models.A10DeviceInstance(
-                id=models._uuid_str(),
+                id=_uuid_str(),
                 tenant_id=context.tenant_id,
                 name=body['name'],
                 username=data['username'],

--- a/a10_neutron_lbaas/neutron_ext/db/a10_device_instance.py
+++ b/a10_neutron_lbaas/neutron_ext/db/a10_device_instance.py
@@ -60,7 +60,7 @@ class A10DeviceInstanceDbMixin(common_db_mixin.CommonDbMixin,
                'default_virtual_server_vrid': a10_device_instance_db.default_virtual_server_vrid,
                'ipinip': a10_device_instance_db.ipinip,
                # Not all device records are nova instances
-               'nova_instance_id': a10_device_instance_db.get('nova_instance_id'),
+               'nova_instance_id': a10_device_instance_db.nova_instance_id,
                'host': a10_device_instance_db.host,
                'write_memory': a10_device_instance_db.write_memory}
         return self._fields(res, fields)
@@ -111,3 +111,11 @@ class A10DeviceInstanceDbMixin(common_db_mixin.CommonDbMixin,
                                     self._make_a10_device_instance_dict, filters=filters,
                                     fields=fields, sorts=sorts, limit=limit,
                                     marker_obj=marker, page_reverse=page_reverse)
+
+    def delete_a10_device_instance(self, context, id):
+        with context.session.begin(subtransactions=True):
+            LOG.debug("A10DeviceInstanceDbMixin:delete_a10_device_instances() id=%s" %
+                      (id))
+            instance = self._get_by_id(context, models.A10DeviceInstance, id)
+            context.session.delete(instance)
+

--- a/a10_neutron_lbaas/neutron_ext/extensions/a10DeviceInstance.py
+++ b/a10_neutron_lbaas/neutron_ext/extensions/a10DeviceInstance.py
@@ -116,3 +116,7 @@ class A10DeviceInstancePluginBase(service_base.ServicePluginBase):
     @abc.abstractmethod
     def get_a10_device_instance(self, context, id, fields=None):
         pass
+
+    @abc.abstractmethod
+    def delete_a10_device_instance(self, context, id):
+        pass

--- a/a10_neutron_lbaas/neutron_ext/services/a10_device_instance/plugin.py
+++ b/a10_neutron_lbaas/neutron_ext/services/a10_device_instance/plugin.py
@@ -43,7 +43,6 @@ class A10DeviceInstancePlugin(a10_device_instance.A10DeviceInstanceDbMixin):
         return super(A10DeviceInstancePlugin, self).get_a10_device_instance(context,
                                                                             id,
                                                                             fields=fields)
-
     # def update_a10_device_instance(self, context, id, a10_device_instance):
     #     LOG.debug(
     #         "A10DeviceInstancePlugin.update_a10_device_instance(): id=%s, instance=%s",
@@ -54,6 +53,6 @@ class A10DeviceInstancePlugin(a10_device_instance.A10DeviceInstanceDbMixin):
     #         id,
     #         a10_device_instance)
 
-    # def delete_a10_device_instance(self, context, id):
-    #     LOG.debug("A10DeviceInstancePlugin.delete(): id=%s", id)
-    #     return super(A10DeviceInstancePlugin, self).delete_a10_device_instance(context, id)
+    def delete_a10_device_instance(self, context, id):
+        LOG.debug("A10DeviceInstancePlugin.delete(): id=%s", id)
+        return super(A10DeviceInstancePlugin, self).delete_a10_device_instance(context, id)

--- a/a10_neutron_lbaas/vthunder/instance_manager.py
+++ b/a10_neutron_lbaas/vthunder/instance_manager.py
@@ -17,6 +17,8 @@ import pprint
 import time
 import uuid
 
+import glanceclient.client as glance_client
+
 import neutronclient.neutron.client as neutron_client
 
 import novaclient.client as nova_client
@@ -35,8 +37,8 @@ LOG = logging.getLogger(__name__)
 CREATE_TIMEOUT = 900
 
 # TODO(mdurrant) - These may need to go into a configuration file.
-GLANCE_VERSION = 2
-KEYSTONE_VERSION = "2.0"
+GLANCE_VERSION = 2.1
+KEYSTONE_VERSION = "3.0"
 NOVA_VERSION = "2.1"
 NEUTRON_VERSION = "2.0"
 OS_INTERFACE_URLS = ["public", "publicURL"]
@@ -86,6 +88,8 @@ class InstanceManager(object):
             nova_version, session=self._ks_session)
         self._neutron_api = neutron_api or neutron_client.Client(
             NEUTRON_VERSION, session=self._ks_session)
+        self._glance_api = glance_api or glance_client.Client(
+            GLANCE_VERSION, session=self._ks_session)
 
     @classmethod
     def _factory_with_service_tenant(cls, config, user_keystone_session):
@@ -245,7 +249,7 @@ class InstanceManager(object):
                       ((hasattr(x, "name") and x.name is not None and identifier in x.name)
                        or (hasattr(x, "id") and x.id == identifier)))
         try:
-            images = self._nova_api.images.list()
+            images = self._glance_api.images.list()
         except Exception as ex:
             raise a10_ex.ImageNotFoundError(
                 "Unable to retrieve images from nova.  Error %s" % (ex))

--- a/a10_neutron_lbaas/vthunder/keystone.py
+++ b/a10_neutron_lbaas/vthunder/keystone.py
@@ -96,3 +96,23 @@ class KeystoneFromContext(KeystoneBase):
             raise a10_ex.InvalidConfig('keystone version must be protovol version 2 or 3')
 
         return self._get_keystone_stuff(ks_version, auth)
+
+
+class KeystoneFromHorizonRequest(KeystoneBase):
+    def __init__(self, a10_config, request):
+        self.request = request
+        (self._session, self._keystone_client) = self._get_keystone_token(
+            ks_version=a10_config.get('keystone_version'),
+            auth_url=a10_config.get('keystone_auth_url'),
+            auth_token=request.user.token.unscoped_token,
+            tenant_id=request.user.tenant_id)
+
+    def _get_keystone_token(self, ks_version, auth_url, auth_token, tenant_id):
+        if int(ks_version) == 2:
+            auth = v2.Token(auth_url=auth_url, token=auth_token, tenant_id=tenant_id)
+        elif int(ks_version) == 3:
+            auth = v3.Token(auth_url=auth_url, token=auth_token, tenant_id=tenant_id)
+        else:
+            raise a10_ex.InvalidConfig('keystone version must be protovol version 2 or 3')
+
+        return self._get_keystone_stuff(ks_version, auth)

--- a/a10_neutron_lbaas/vthunder/keystone.py
+++ b/a10_neutron_lbaas/vthunder/keystone.py
@@ -91,7 +91,7 @@ class KeystoneFromContext(KeystoneBase):
         if int(ks_version) == 2:
             auth = v2.Token(auth_url=auth_url, token=auth_token, tenant_id=tenant_id)
         elif int(ks_version) == 3:
-            auth = v3.Token(auth_url=auth_url, token=auth_token, tenant_id=tenant_id)
+            auth = v3.Token(auth_url=auth_url, token=auth_token, project_id=tenant_id)
         else:
             raise a10_ex.InvalidConfig('keystone version must be protovol version 2 or 3')
 
@@ -111,7 +111,7 @@ class KeystoneFromHorizonRequest(KeystoneBase):
         if int(ks_version) == 2:
             auth = v2.Token(auth_url=auth_url, token=auth_token, tenant_id=tenant_id)
         elif int(ks_version) == 3:
-            auth = v3.Token(auth_url=auth_url, token=auth_token, tenant_id=tenant_id)
+            auth = v3.Token(auth_url=auth_url, token=auth_token, project_id=tenant_id)
         else:
             raise a10_ex.InvalidConfig('keystone version must be protovol version 2 or 3')
 


### PR DESCRIPTION
Allows creation of Keystone context from existing Horizon request
Provides Keystone v3 authentication
Makes nova_instance_id field optional as not all a10 devices are going to be nova instances.
What looks like a complete re-write of the device extension but in fact just repairs Windows line endings.