### PR TITLE
Per tenant scaling group binding

### DIFF
--- a/a10_neutron_lbaas/db/migration/alembic.ini
+++ b/a10_neutron_lbaas/db/migration/alembic.ini
@@ -2,7 +2,7 @@
 
 [alembic]
 # path to migration scripts
-script_location = alembic_migrations
+script_location = %(here)s/alembic_migrations
 
 # template used to generate migration files
 # file_template = %%(rev)s_%%(slug)s

--- a/a10_neutron_lbaas/db/migration/alembic_migrations/script.py.mako
+++ b/a10_neutron_lbaas/db/migration/alembic_migrations/script.py.mako
@@ -1,3 +1,15 @@
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
 """${message}
 
 Revision ID: ${up_revision}

--- a/a10_neutron_lbaas/db/migration/alembic_migrations/versions/357cd913dae6_scaling_group_tenant_binding_table.py
+++ b/a10_neutron_lbaas/db/migration/alembic_migrations/versions/357cd913dae6_scaling_group_tenant_binding_table.py
@@ -1,0 +1,49 @@
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+"""scaling group tenant binding table
+
+Revision ID: 357cd913dae6
+Revises: 3c7123f2aeba
+Create Date: 2016-06-02 17:47:12.736929
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '357cd913dae6'
+down_revision = '3c7123f2aeba'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.create_table(
+        "a10_scaling_group_tenant_bindings",
+        sa.Column('id',
+                  sa.String(36),
+                  primary_key=True,
+                  nullable=False),
+        sa.Column('created_at', sa.DateTime, nullable=False),
+        sa.Column('updated_at', sa.DateTime, nullable=False),
+        sa.Column('scaling_group_id', sa.String(36),
+                  sa.ForeignKey('a10_scaling_groups.id'),
+                  nullable=False),
+        sa.Column('tenant_id', sa.String(255),
+                  nullable=False),
+    )
+
+
+def downgrade():
+    op.drop_table("a10_scaling_group_tenant_bindings")

--- a/a10_neutron_lbaas/db/migration/alembic_migrations/versions/3a4bbcea6e1e_a10_tenant_bindings_created_at_nullable.py
+++ b/a10_neutron_lbaas/db/migration/alembic_migrations/versions/3a4bbcea6e1e_a10_tenant_bindings_created_at_nullable.py
@@ -1,0 +1,41 @@
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+"""a10_tenant_bindings created_at nullable
+
+Revision ID: 3a4bbcea6e1e
+Revises: 53ef3417bbaa
+Create Date: 2016-08-05 20:17:00.492616
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '3a4bbcea6e1e'
+down_revision = '53ef3417bbaa'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.alter_column('a10_tenant_bindings', 'created_at',
+                    type_=sa.DateTime, nullable=False,
+                    existing_type=sa.DateTime, existing_nullable=True)
+    op.alter_column('a10_tenant_bindings', 'updated_at',
+                    type_=sa.DateTime, nullable=False,
+                    existing_type=sa.DateTime, existing_nullable=True)
+
+
+def downgrade():
+    pass

--- a/a10_neutron_lbaas/db/migration/alembic_migrations/versions/3e6dafba6b22_a10_scaling_group_tenant_binding_.py
+++ b/a10_neutron_lbaas/db/migration/alembic_migrations/versions/3e6dafba6b22_a10_scaling_group_tenant_binding_.py
@@ -1,0 +1,52 @@
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+"""a10_scaling_group_tenant_binding_loadbalancers
+
+Revision ID: 3e6dafba6b22
+Revises: 3a4bbcea6e1e
+Create Date: 2016-08-05 22:22:55.910160
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '3e6dafba6b22'
+down_revision = '3a4bbcea6e1e'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.create_table(
+        "a10_scaling_group_tenant_binding_loadbalancers",
+        sa.Column('id',
+                  sa.String(36),
+                  primary_key=True,
+                  nullable=False),
+        sa.Column('created_at', sa.DateTime, nullable=False),
+        sa.Column('updated_at', sa.DateTime, nullable=False),
+        sa.Column('tenant_binding_id',
+                  sa.String(36),
+                  sa.ForeignKey('a10_scaling_group_tenant_bindings.id'),
+                  nullable=False),
+        sa.Column('lbaas_loadbalancer_id',
+                  sa.String(36),
+                  unique=True,
+                  nullable=False)
+    )
+
+
+def downgrade():
+    op.drop_table('a10_scaling_group_tenant_binding_loadbalancers')

--- a/a10_neutron_lbaas/db/migration/alembic_migrations/versions/53ef3417bbaa_a10_device_instance_api_version_width.py
+++ b/a10_neutron_lbaas/db/migration/alembic_migrations/versions/53ef3417bbaa_a10_device_instance_api_version_width.py
@@ -1,0 +1,38 @@
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+"""a10_device_instance api_version width
+
+Revision ID: 53ef3417bbaa
+Revises: 357cd913dae6
+Create Date: 2016-08-05 20:08:16.496817
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '53ef3417bbaa'
+down_revision = '357cd913dae6'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.alter_column('a10_device_instances', 'api_version',
+                    type_=sa.String(12), nullable=False,
+                    existing_type=sa.String(255), existing_nullable=False)
+
+
+def downgrade():
+    pass

--- a/a10_neutron_lbaas/db/migration/alembic_migrations/versions/78d283c111ac_a10_certificates_tenant_id_column_type.py
+++ b/a10_neutron_lbaas/db/migration/alembic_migrations/versions/78d283c111ac_a10_certificates_tenant_id_column_type.py
@@ -10,27 +10,27 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-"""${message}
+"""a10_certificates tenant_id column type
 
-Revision ID: ${up_revision}
-Revises: ${down_revision | comma,n}
-Create Date: ${create_date}
+Revision ID: 78d283c111ac
+Revises: 9458ad898897
+Create Date: 2017-02-01 22:53:47.229207
 
 """
 
 # revision identifiers, used by Alembic.
-revision = ${repr(up_revision)}
-down_revision = ${repr(down_revision)}
-branch_labels = ${repr(branch_labels)}
-depends_on = ${repr(depends_on)}
+revision = '78d283c111ac'
+down_revision = '9458ad898897'
+branch_labels = None
+depends_on = None
 
-from alembic import op  # noqa
-import sqlalchemy as sa  # noqa
-${imports if imports else ""}
+from alembic import op
+import sqlalchemy as sa
+
 
 def upgrade():
-    ${upgrades if upgrades else "pass"}
+    op.alter_column('a10_certificates', 'tenant_id', type_=sa.String(36), nullable=False)
 
 
 def downgrade():
-    ${downgrades if downgrades else "pass"}
+    op.alter_column('a10_certificates', 'tenant_id', type_=sa.String(255), nullable=True)

--- a/a10_neutron_lbaas/db/migration/alembic_migrations/versions/9458ad898897_.py
+++ b/a10_neutron_lbaas/db/migration/alembic_migrations/versions/9458ad898897_.py
@@ -10,27 +10,24 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-"""${message}
+"""empty message
 
-Revision ID: ${up_revision}
-Revises: ${down_revision | comma,n}
-Create Date: ${create_date}
+Revision ID: 9458ad898897
+Revises: 4ffd7ee0f175, 3e6dafba6b22
+Create Date: 2017-02-01 22:52:28.324438
 
 """
 
 # revision identifiers, used by Alembic.
-revision = ${repr(up_revision)}
-down_revision = ${repr(down_revision)}
-branch_labels = ${repr(branch_labels)}
-depends_on = ${repr(depends_on)}
+revision = '9458ad898897'
+down_revision = ('4ffd7ee0f175', '3e6dafba6b22')
+branch_labels = None
+depends_on = None
 
-from alembic import op  # noqa
-import sqlalchemy as sa  # noqa
-${imports if imports else ""}
 
 def upgrade():
-    ${upgrades if upgrades else "pass"}
+    pass
 
 
 def downgrade():
-    ${downgrades if downgrades else "pass"}
+    pass

--- a/a10_neutron_lbaas/db/models/a10_certificates.py
+++ b/a10_neutron_lbaas/db/models/a10_certificates.py
@@ -32,6 +32,6 @@ class CertificateListenerBinding(model_base.A10BaseMixin, model_base.A10Base):
     certificate_id = sa.Column(sa.String(36), sa.ForeignKey("a10_certificates.id"),
                                nullable=False)
     certificate = orm.relationship(Certificate, uselist=False)
-    listener_id = sa.Column(sa.String(36))
+    listener_id = sa.Column(sa.String(36), nullable=False)
     # This is a TINYINT/BYTE field depending on SQL implementation
     status = sa.Column(sa.Integer(), default=0)

--- a/a10_neutron_lbaas/db/models/a10_certificates.py
+++ b/a10_neutron_lbaas/db/models/a10_certificates.py
@@ -34,4 +34,4 @@ class CertificateListenerBinding(model_base.A10BaseMixin, model_base.A10Base):
     certificate = orm.relationship(Certificate, uselist=False)
     listener_id = sa.Column(sa.String(36), nullable=False)
     # This is a TINYINT/BYTE field depending on SQL implementation
-    status = sa.Column(sa.Integer(), default=0)
+    status = sa.Column(sa.Integer(), default=0, nullable=False, server_default="0")

--- a/a10_neutron_lbaas/db/models/a10_device_instance.py
+++ b/a10_neutron_lbaas/db/models/a10_device_instance.py
@@ -38,7 +38,7 @@ class A10DeviceInstance(model_base.A10BaseMixin, model_base.A10Base):
     ipinip = sa.Column(sa.Boolean(), nullable=False)
     write_memory = sa.Column(sa.Boolean(), nullable=False)
 
-    nova_instance_id = sa.Column(sa.String(36), nullable=True)
+    nova_instance_id = sa.Column(sa.String(36), nullable=False)
     host = sa.Column(sa.String(255), nullable=False)
 
     # TODO(dougwig) -- later - reference to scheduler, or capacity, or?

--- a/a10_neutron_lbaas/db/models/scaling_group.py
+++ b/a10_neutron_lbaas/db/models/scaling_group.py
@@ -81,6 +81,24 @@ class A10ScalingGroupTenantBinding(models.A10Base):
     tenant_id = sa.Column(sa.String(255), nullable=False)
 
 
+class A10ScalingGroupTenantBindingLoadbalancer(models.A10Base):
+    __tablename__ = u'a10_scaling_group_tenant_binding_loadbalancers'
+
+    id = sa.Column(sa.String(36),
+                   primary_key=True,
+                   nullable=False,
+                   default=models._uuid_str)
+
+    tenant_binding_id = sa.Column(sa.String(36),
+                                  sa.ForeignKey('a10_scaling_group_tenant_bindings.id'),
+                                  nullable=False)
+    tenant_binding = relationship(A10ScalingGroupTenantBinding, backref='loadbalancers')
+
+    lbaas_loadbalancer_id = sa.Column(sa.String(36),
+                                      unique=True,
+                                      nullable=False)
+
+
 class A10ScalingGroupMember(models.A10Base):
     """A10 Scaling Group Member - switch/worker depending on 'role'"""
     __tablename__ = "a10_scaling_group_members"

--- a/a10_neutron_lbaas/db/models/scaling_group.py
+++ b/a10_neutron_lbaas/db/models/scaling_group.py
@@ -66,6 +66,21 @@ class A10ScalingGroupBinding(models.A10Base):
                                       nullable=False)
 
 
+class A10ScalingGroupTenantBinding(models.A10Base):
+    __tablename__ = u'a10_scaling_group_tenant_bindings'
+
+    id = sa.Column(sa.String(36),
+                   primary_key=True,
+                   nullable=False,
+                   default=models._uuid_str)
+    scaling_group_id = sa.Column(sa.String(36),
+                                 sa.ForeignKey('a10_scaling_groups.id'),
+                                 nullable=False)
+    scaling_group = relationship(A10ScalingGroup, backref='tenant_bindings')
+
+    tenant_id = sa.Column(sa.String(255), nullable=False)
+
+
 class A10ScalingGroupMember(models.A10Base):
     """A10 Scaling Group Member - switch/worker depending on 'role'"""
     __tablename__ = "a10_scaling_group_members"

--- a/a10_neutron_lbaas/tests/db/migration/test_base.py
+++ b/a10_neutron_lbaas/tests/db/migration/test_base.py
@@ -1,4 +1,4 @@
-# Copyright 2015,  A10 Networks
+# Copyright 2016,  A10 Networks
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
 #    not use this file except in compliance with the License. You may obtain
@@ -10,7 +10,9 @@
 #    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
-#    under the License.
+#    under the License.from neutron.db import model_base
+
+import sqlalchemy.orm
 
 from a10_neutron_lbaas.tests.db import session
 from a10_neutron_lbaas.tests import test_case
@@ -19,11 +21,8 @@ from a10_neutron_lbaas.tests import test_case
 class UnitTestBase(test_case.TestCase):
 
     def setUp(self):
-        super(UnitTestBase, self).setUp()
-        (open_session, close_session) = session.fake_session()
-        self.open_session = open_session
-        self.close_session = close_session
+        self.connection = session.fake_migration_connection()
+        self.Session = sqlalchemy.orm.sessionmaker(bind=self.connection)
 
     def tearDown(self):
-        super(UnitTestBase, self).tearDown()
-        self.close_session()
+        self.connection.close()

--- a/a10_neutron_lbaas/tests/db/migration/test_base.py
+++ b/a10_neutron_lbaas/tests/db/migration/test_base.py
@@ -14,15 +14,12 @@
 
 import sqlalchemy.orm
 
-from a10_neutron_lbaas.tests.db import session
-from a10_neutron_lbaas.tests import test_case
+from a10_neutron_lbaas.tests.db import test_base
 
 
-class UnitTestBase(test_case.TestCase):
+class UnitTestBase(test_base.DbTestBase):
 
     def setUp(self):
-        self.connection = session.fake_migration_connection()
-        self.Session = sqlalchemy.orm.sessionmaker(bind=self.connection)
+        super(UnitTestBase, self).setUp()
 
-    def tearDown(self):
-        self.connection.close()
+        self.Session = sqlalchemy.orm.sessionmaker(bind=self.connection)

--- a/a10_neutron_lbaas/tests/db/migration/test_migrations.py
+++ b/a10_neutron_lbaas/tests/db/migration/test_migrations.py
@@ -95,13 +95,17 @@ class TestMigrations(test_base.UnitTestBase):
             # We don't care about display width
             if getattr(copied_type, 'display_width', None) is not None:
                 copied_type.display_width = None
+            if type(schema_type) is sqlalchemy.sql.sqltypes.Text:
+                copied_type.length = None
+
             normalized_type = copied_type.compile(dialect=self.connection.dialect)
 
             # mysql has some weird synonyms
             if self.connection.dialect.name == 'mysql':
                 weird_synonyms = {
                     'BOOL': 'TINYINT',
-                    'BOOLEAN': 'TINYINT'
+                    'BOOLEAN': 'TINYINT',
+                    'TEXT()': 'TEXT'
                 }
                 normalized_type = weird_synonyms.get(normalized_type, normalized_type)
 
@@ -109,8 +113,6 @@ class TestMigrations(test_base.UnitTestBase):
 
         for model in a10_models:
             columns = inspection.get_columns(model.__tablename__)
-
-            # import pdb; pdb.set_trace()
 
             actual_columns = sorted([
                 {

--- a/a10_neutron_lbaas/tests/db/migration/test_migrations.py
+++ b/a10_neutron_lbaas/tests/db/migration/test_migrations.py
@@ -1,0 +1,135 @@
+# Copyright 2016,  A10 Networks
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.from neutron.db import model_base
+
+import mock
+import os
+
+import alembic.command as alembic_command
+import alembic.config as alembic_config
+import alembic.op as op
+import sqlalchemy
+
+import a10_neutron_lbaas.db.migration as migration
+import a10_neutron_lbaas.tests.db.session as session
+import test_base
+
+
+class TestMigrations(test_base.UnitTestBase):
+
+    def setUp(self):
+        super(TestMigrations, self).setUp()
+        self.patch_create_engine = mock.patch.object(sqlalchemy,
+                                                     'create_engine',
+                                                     return_value=self.connection)
+        self.patch_create_engine.__enter__()
+
+        create_index = op.create_index
+        drop_index = op.drop_index
+
+        def create_uniquely_named_index(name, tname, *args, **kwargs):
+            return create_index(tname + '_' + name, tname, *args, **kwargs)
+
+        def drop_uniquely_named_index(name, *args, **kwargs):
+            return drop_index((kwargs.get('table_name') or args[0]) + '_' + name, *args, **kwargs)
+
+        self.patch_op_create_index = mock.patch.object(op,
+                                                       'create_index',
+                                                       side_effect=create_uniquely_named_index)
+        self.patch_op_drop_index = mock.patch.object(op,
+                                                     'drop_index',
+                                                     side_effect=drop_uniquely_named_index)
+        self.patch_op_create_index.__enter__()
+        self.patch_op_drop_index.__enter__()
+
+    def tearDown(self):
+        self.patch_op_drop_index.__exit__()
+        self.patch_op_create_index.__exit__()
+        self.patch_create_engine.__exit__()
+        super(TestMigrations, self).tearDown()
+
+    def config(self):
+        config = alembic_config.Config(
+            os.path.join(os.path.dirname(migration.__file__), 'alembic.ini')
+        )
+        config.connection = self.connection
+        return config
+
+    def upgrade(self, revision):
+        alembic_command.upgrade(self.config(), revision)
+
+    def downgrade(self, revision):
+        alembic_command.downgrade(self.config(), revision)
+
+    def test_install(self):
+        self.upgrade('heads')
+
+    def test_install_schema_matches_model_schema(self):
+        self.upgrade('heads')
+
+        a10_models = session.a10_models()
+
+        inspection = sqlalchemy.inspect(self.connection)
+        tables = inspection.get_table_names()
+
+        missing_tables = [model.__tablename__ for model in a10_models if
+                          model.__tablename__ not in tables]
+        self.assertEqual([], missing_tables,
+                         "The following tables weren't created by installing {0}".
+                         format(missing_tables))
+
+        for model in a10_models:
+            columns = inspection.get_columns(model.__tablename__)
+
+            actual_columns = sorted([
+                {
+                    'primary_key': True if c['primary_key'] else False,
+                    'nullable': c['nullable'],
+                    'default': c['default'],
+                    'autoincrement': c['autoincrement'],
+                    'type': c['type'].compile(dialect=self.connection.dialect),
+                    'name': unicode(c['name'])
+                }
+                for c in columns],
+                key=lambda x: x['name'])
+
+            mapper = sqlalchemy.inspect(model)
+
+            expected_columns = sorted([
+                {
+                    'primary_key': c.primary_key,
+                    'nullable': c.nullable,
+                    'default': c.server_default,
+                    'autoincrement': c.autoincrement,
+                    'type': c.type.compile(dialect=self.connection.dialect),
+                    'name': unicode(c.name)
+                }
+                for c in mapper.columns
+                if c.table.name == model.__tablename__],
+                key=lambda x: x['name'])
+
+            if (actual_columns != expected_columns):
+                print ("The model and installed columns for {0} don't match".
+                       format(model.__tablename__))
+                print ("Model columns    ", [c['name'] for c in expected_columns])
+                print ("Installed columns", [c['name'] for c in actual_columns])
+            self.assertEqual(expected_columns, actual_columns)
+
+    def test_upgrade_heads_downgrade_base(self):
+        self.upgrade('heads')
+        self.downgrade('base')
+
+    def test_upgrade_heads_downgrade_base_upgrade_heads(self):
+        self.upgrade('heads')
+        self.downgrade('base')
+        self.upgrade('heads')

--- a/a10_neutron_lbaas/tests/db/migration/test_migrations.py
+++ b/a10_neutron_lbaas/tests/db/migration/test_migrations.py
@@ -80,6 +80,7 @@ class TestMigrations(test_base.UnitTestBase):
         a10_models = session.a10_models()
 
         inspection = sqlalchemy.inspect(self.connection)
+
         tables = inspection.get_table_names()
 
         missing_tables = [model.__tablename__ for model in a10_models if

--- a/a10_neutron_lbaas/tests/db/neutron_ext/db/test_a10_device_instance.py
+++ b/a10_neutron_lbaas/tests/db/neutron_ext/db/test_a10_device_instance.py
@@ -17,6 +17,7 @@ import mock
 from a10_openstack_lib.resources import a10_device_instance as a10_device_instance_resources
 
 import a10_neutron_lbaas.tests.db.test_base as test_base
+import a10_neutron_lbaas.tests.unit.unit_config.helper as unit_config
 
 from a10_neutron_lbaas.neutron_ext.common import constants
 from a10_neutron_lbaas.neutron_ext.db import a10_device_instance as a10_device_instance
@@ -34,9 +35,13 @@ class TestA10DeviceInstanceDbMixin(test_base.UnitTestBase):
             nconstants.LOADBALANCERV2: mock.MagicMock()
         }
 
+        self._config_cleanup = unit_config.use_config_dir()
+
         self.plugin = a10_device_instance.A10DeviceInstanceDbMixin()
 
     def tearDown(self):
+        self._config_cleanup()
+
         super(TestA10DeviceInstanceDbMixin, self).tearDown()
 
     def context(self):
@@ -58,7 +63,7 @@ class TestA10DeviceInstanceDbMixin(test_base.UnitTestBase):
             'v_method': 'LSI',
             'shared_partition': 'shared',
             'write_memory': False,
-            'nova_instance_id': None,
+            'nova_instance_id': 'fake-instance-id',
             'project_id': 'fake-tenant-id'
         }
 

--- a/a10_neutron_lbaas/tests/db/neutron_ext/db/test_certificates.py
+++ b/a10_neutron_lbaas/tests/db/neutron_ext/db/test_certificates.py
@@ -21,7 +21,6 @@ from a10_neutron_lbaas.tests.db import test_base as tbase
 import mock
 from neutron.plugins.common import constants as nconstants
 from neutron.tests.unit.api.v2 import test_base as ntbase
-from neutron_lbaas.db.loadbalancer import models as lb_models
 
 from oslo_log.helpers import logging as logging
 from oslo_utils import uuidutils
@@ -283,44 +282,6 @@ class CertificateDbMixInTestCase(tbase.UnitTestBase):
 
         return self.plugin.create_a10_certificate_listener_binding(ctx, binding), binding
 
-    def _build_vip_dependencies(self, ctx, tenant_id):
-        """Builds Network => Port => Vip to satisfy foreign key constraints"""
-        lb = lb_models.LoadBalancer()
-        # if ctx is None:
-        #     ctx = self.context()
-
-        # with ctx.session.begin(subtransactions=True):
-        #     network = models_v2.Network(id=uuidutils.generate_uuid(),
-        #                                 name='Test Network',
-        #                                 status='Unavailable',
-        #                                 admin_state_up=False)
-
-        #     ctx.session.add(network)
-        #     ctx.session.commit()
-
-        #     network = ctx.session.query(models_v2.Network).filter_by(name='Test Network').first()
-        #     port = models_v2.Port(id=uuidutils.generate_uuid(),
-        #                           name='Test Port', tenant_id=tenant_id,
-        #                           network_id=network['id'],
-        #                           mac_address='13:37:c0:ff:fe:13', admin_state_up=False,
-        #                           device_owner='Test Owner', device_id='Test Device ID',
-        #                           status='INACTIVE')
-
-        #     ctx.session.add(port)
-        #     port = ctx.session.query(models_v2.Port).filter_by(name='Test Port').first()
-        #     # TODO(mdurrant) What does protocol_port do?
-        #     lb = lb_models.LoadBalancer(id=uuidutils.generate_uuid(),
-        #                                 name='Test Vip', description='Test Vip Description',
-        #                                 port_id=port['id'], protocol_port=0, protocol='HTTPS',
-        #                                 pool_id=uuidutils.generate_uuid(), tenant_id=tenant_id,
-        #                                 status='INACTIVE', status_description='INACTIVE',
-        #                                 admin_state_up=False, connection_limit=42)
-
-        #     ctx.session.add(listener)
-        #     listener = ctx.session.query(lb_models.Listener).filter_by(
-        #         name='Test Listener').first()
-        return lb
-
     def test_create_certificate(self, tenant_id="tenant1"):
         ctx = self.context()
         record, request = self._create_certificate(tenant_id)
@@ -370,8 +331,7 @@ class CertificateDbMixInTestCase(tbase.UnitTestBase):
 
     def test_create_certificate_binding(self):
         ctx = self.context()
-        vip = self._build_vip_dependencies(ctx, _tenant_id)
-        vip_uuid = vip['id']
+        vip_uuid = 'fake-listener-id'
         cert, data = self._create_certificate()
         binding = self._build_binding(cert['id'], vip_uuid)
         self.plugin.create_a10_certificate_binding(ctx, binding)
@@ -384,9 +344,7 @@ class CertificateDbMixInTestCase(tbase.UnitTestBase):
 
     def test_delete_certificate_binding(self):
         ctx = self.context()
-        vip = self._build_vip_dependencies(ctx, _tenant_id)
-        vip_uuid = vip['id']
-
+        vip_uuid = 'fake-listener-id'
         cert, data = self._create_certificate()
         binding = self._build_binding(cert['id'], vip_uuid)
         self.plugin.create_a10_certificate_binding(ctx, binding)

--- a/a10_neutron_lbaas/tests/db/session.py
+++ b/a10_neutron_lbaas/tests/db/session.py
@@ -12,9 +12,18 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+from sqlalchemy.ext.declarative import clsregistry
 from sqlalchemy.orm import sessionmaker
 
 from a10_neutron_lbaas.db import api as db_api
+
+# Import models to be created by create_all
+import a10_neutron_lbaas.db.models
+import a10_neutron_lbaas.db.models.scaling_group
+
+# Suppress pep8 warnings for unused imports
+assert a10_neutron_lbaas.db.models
+assert a10_neutron_lbaas.db.models.scaling_group
 
 Base = db_api.get_base()
 
@@ -41,15 +50,10 @@ def fake_session(tables=None):
     return (make_session, connection.close)
 
 
-def a10_neutron_lbaas_models():
-    return [model
-            for model in Base._decl_class_registry.values()
-            if model.__module__.startswith('a10_neutron_lbaas.')]
+def a10_models():
+    return [model for model in Base._decl_class_registry.values()
+            if not isinstance(model, clsregistry._ModuleMarker)]
 
 
 def fake_migration_connection():
-    a10_neutron_lbaas_tables = [model.__tablename__ for model in a10_neutron_lbaas_models()]
-    other_tables = [table
-                    for table in Base.metadata.sorted_tables
-                    if table.name not in a10_neutron_lbaas_tables]
-    return fake_connection(other_tables)
+    return fake_connection([])

--- a/a10_neutron_lbaas/tests/db/test_a10_tenant_bindings.py
+++ b/a10_neutron_lbaas/tests/db/test_a10_tenant_bindings.py
@@ -18,7 +18,7 @@ from a10_neutron_lbaas.db import models
 
 import test_base
 
-dt = datetime.datetime.fromtimestamp(1458346727.132739)
+dt = datetime.datetime.fromtimestamp(1458346727)
 
 
 class TestTenantBindings(test_base.UnitTestBase):

--- a/a10_neutron_lbaas/tests/unit/test_base.py
+++ b/a10_neutron_lbaas/tests/unit/test_base.py
@@ -12,10 +12,10 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-import os
+import mock
 
 import a10_neutron_lbaas.tests.test_case as test_case
-import mock
+import a10_neutron_lbaas.tests.unit.unit_config.helper as unit_config
 
 import a10_neutron_lbaas.a10_openstack_lb as a10_os
 import a10_neutron_lbaas.plumbing_hooks as hooks
@@ -74,9 +74,8 @@ class UnitTestBase(test_case.TestCase):
 
     def setUp(self, openstack_lb_args={}):
         super(UnitTestBase, self).setUp()
-        unit_dir = os.path.dirname(__file__)
-        unit_config = os.path.join(unit_dir, "unit_config")
-        os.environ['A10_CONFIG_DIR'] = unit_config
+
+        self._config_cleanup = unit_config.use_config_dir()
 
         if 'provider' not in openstack_lb_args:
             openstack_lb_args['provider'] = 'units'
@@ -85,6 +84,9 @@ class UnitTestBase(test_case.TestCase):
             self.a = FakeA10OpenstackLBV2(mock.MagicMock(), **openstack_lb_args)
         else:
             self.a = FakeA10OpenstackLBV1(mock.MagicMock(), **openstack_lb_args)
+
+    def tearDown(self):
+        self._config_cleanup()
 
     def print_mocks(self):
         print("OPENSTACK ", self.a.openstack_driver.mock_calls)

--- a/a10_neutron_lbaas/tests/unit/unit_config/helper.py
+++ b/a10_neutron_lbaas/tests/unit/unit_config/helper.py
@@ -10,6 +10,8 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+import os
+
 from a10_neutron_lbaas import a10_config
 from a10_neutron_lbaas.etc import config as blank_config
 
@@ -21,3 +23,22 @@ def empty_config():
 def config(config_dict):
     config_constructor = type('config', (object,), config_dict)
     return a10_config.A10Config(config=config_constructor())
+
+
+def use_config_dir(config_dir=None):
+    if config_dir is None:
+        config_dir = os.path.dirname(__file__)
+
+    if 'A10_CONFIG_DIR' in os.environ:
+        current = os.environ['A10_CONFIG_DIR']
+
+        def cleanup():
+            os.environ['A10_CONFIG_DIR'] = current
+    else:
+
+        def cleanup():
+            del os.environ['A10_CONFIG_DIR']
+
+    os.environ['A10_CONFIG_DIR'] = config_dir
+
+    return cleanup

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -11,7 +11,6 @@ nose-exclude
 oslotest
 pifpaf
 pymysql
-sqlalchemy-utils
 testresources
 testscenarios
 # TODO(dougwig) -- can we remove this?

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -9,7 +9,9 @@ mox3
 nose
 nose-exclude
 oslotest
+pifpaf
 pymysql
+sqlalchemy-utils
 testresources
 testscenarios
 # TODO(dougwig) -- can we remove this?

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ install_command = pip install -U {opts} {packages}
 deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
 commands =
-  nosetests {posargs}
+  pifpaf run mysql nosetests {posargs}
 
 [testenv:pep8]
 commands =
@@ -32,6 +32,6 @@ max-line-length = 100
 whitelist_externals = find
 commands = find {toxinidir} -name "*.pyc" -type f -delete
            coverage erase
-           nosetests --with-coverage --cover-inclusive --cover-html --cover-html-dir={toxinidir}/htmlcov
+           pifpaf run mysql nosetests --with-coverage --cover-inclusive --cover-html --cover-html-dir={toxinidir}/htmlcov
 deps = coverage
        {[testenv]deps}

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ install_command = pip install -U {opts} {packages}
 deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
 commands =
-  pifpaf run mysql nosetests {posargs}
+  pifpaf run mysql -- nosetests {posargs}
 
 [testenv:pep8]
 commands =
@@ -32,6 +32,6 @@ max-line-length = 100
 whitelist_externals = find
 commands = find {toxinidir} -name "*.pyc" -type f -delete
            coverage erase
-           pifpaf run mysql nosetests --with-coverage --cover-inclusive --cover-html --cover-html-dir={toxinidir}/htmlcov
+           pifpaf run mysql -- nosetests --with-coverage --cover-inclusive --cover-html --cover-html-dir={toxinidir}/htmlcov
 deps = coverage
        {[testenv]deps}


### PR DESCRIPTION
Models for a10-openstack's beehive per tenant binding.

For https://github.com/a10networks/a10-openstack-planning/issues/17

---
- scaling group tenant binding table
- a10_scaling_group_tenant_binding_loadbalancers table
- allowed_address_pairs default the mac address when unspecified

Includes testing improvements and fixes for errors discovered by testing improvements
- Tests for migrations, add license to new migrations
- glance client is no longer used in instance manager
- Run tests with mysql
- Create new database for each test
- Fix db column types
