### PR TITLE
Instance Manager fixes for a10-horizon - nova_instance_id/keystone context builder

### DIFF
--- a/a10_neutron_lbaas/db/migration/alembic_migrations/versions/2a280aba7701_create_orchestration.py
+++ b/a10_neutron_lbaas/db/migration/alembic_migrations/versions/2a280aba7701_create_orchestration.py
@@ -50,7 +50,7 @@ def upgrade():
         sa.Column('ipinip', sa.Boolean(), nullable=False),
         sa.Column('write_memory', sa.Boolean(), nullable=False),
 
-        sa.Column('nova_instance_id', sa.String(36), nullable=False),
+        sa.Column('nova_instance_id', sa.String(36), nullable=True),
         sa.Column('host', sa.String(255), nullable=False)
     )
     op.create_table(

--- a/a10_neutron_lbaas/db/migration/alembic_migrations/versions/2a280aba7701_create_orchestration.py
+++ b/a10_neutron_lbaas/db/migration/alembic_migrations/versions/2a280aba7701_create_orchestration.py
@@ -50,7 +50,7 @@ def upgrade():
         sa.Column('ipinip', sa.Boolean(), nullable=False),
         sa.Column('write_memory', sa.Boolean(), nullable=False),
 
-        sa.Column('nova_instance_id', sa.String(36), nullable=True),
+        sa.Column('nova_instance_id', sa.String(36), nullable=False),
         sa.Column('host', sa.String(255), nullable=False)
     )
     op.create_table(

--- a/a10_neutron_lbaas/db/migration/alembic_migrations/versions/bc5626a5af2a_nova_instance_id_not_required.py
+++ b/a10_neutron_lbaas/db/migration/alembic_migrations/versions/bc5626a5af2a_nova_instance_id_not_required.py
@@ -1,3 +1,15 @@
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
 """Nova instance ID not required
 
 Revision ID: bc5626a5af2a

--- a/a10_neutron_lbaas/db/migration/alembic_migrations/versions/bc5626a5af2a_nova_instance_id_not_required.py
+++ b/a10_neutron_lbaas/db/migration/alembic_migrations/versions/bc5626a5af2a_nova_instance_id_not_required.py
@@ -1,0 +1,26 @@
+"""Nova instance ID not required
+
+Revision ID: bc5626a5af2a
+Revises: 3c7123f2aeba
+Create Date: 2016-10-27 18:47:41.163902
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'bc5626a5af2a'
+down_revision = '3c7123f2aeba'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.alter_column('a10_device_instances',
+                    sa.Column('nova_instance_id', sa.String(36), nullable=True))
+
+
+def downgrade():
+    op.alter_column('a10_device_instances',
+                    sa.Column('nova_instance_id', sa.String(36), nullable=False))

--- a/a10_neutron_lbaas/neutron_ext/common/attributes.py
+++ b/a10_neutron_lbaas/neutron_ext/common/attributes.py
@@ -37,7 +37,10 @@ def _find(*args):
 
 convert_to_int = _find(lambda: old_attributes.convert_to_int,
                        lambda: lib_converters.convert_to_int)
+
 convert_kvp_list_to_dict = _find(lambda: old_attributes.convert_kvp_list_to_dict,
                                  lambda: lib_converters.convert_kvp_list_to_dict)
+convert_to_list = _find(lambda: old_attributes.convert_to_list,
+                        lambda: lib_converters.convert_to_list)
 ATTR_NOT_SPECIFIED = _find(lambda: old_attributes.ATTR_NOT_SPECIFIED,
                            lambda: lib_constants.ATTR_NOT_SPECIFIED)

--- a/a10_neutron_lbaas/neutron_ext/common/attributes.py
+++ b/a10_neutron_lbaas/neutron_ext/common/attributes.py
@@ -42,5 +42,8 @@ convert_kvp_list_to_dict = _find(lambda: old_attributes.convert_kvp_list_to_dict
                                  lambda: lib_converters.convert_kvp_list_to_dict)
 convert_to_list = _find(lambda: old_attributes.convert_to_list,
                         lambda: lib_converters.convert_to_list)
+convert_kvp_to_list = _find(lambda: old_attributes.convert_kvp_to_list,
+                            lambda: lib_converters.convert_kvp_to_list)
+
 ATTR_NOT_SPECIFIED = _find(lambda: old_attributes.ATTR_NOT_SPECIFIED,
                            lambda: lib_constants.ATTR_NOT_SPECIFIED)

--- a/a10_neutron_lbaas/neutron_ext/common/resources.py
+++ b/a10_neutron_lbaas/neutron_ext/common/resources.py
@@ -14,7 +14,7 @@
 
 import collections
 
-from neutron.api.v2 import attributes
+import attributes
 
 import six
 

--- a/a10_neutron_lbaas/neutron_ext/db/a10_device_instance.py
+++ b/a10_neutron_lbaas/neutron_ext/db/a10_device_instance.py
@@ -119,8 +119,10 @@ class A10DeviceInstanceDbMixin(common_db_mixin.CommonDbMixin,
             instance = self._get_by_id(context, models.A10DeviceInstance, id)
             context.session.delete(instance)
 
-    def update_a10_device_instance(self, context, a10_device_instance):
+    def update_a10_device_instance(self, context, id, a10_device_instance):
         with context.session.begin(subtransactions=True):
             instance = self._get_by_id(context, models.A10DeviceInstance,
-                                       a10_device_instance.get("id"))
-            context.session.update(instance)
+                                       id)
+            instance.update(**a10_device_instance.get("a10_device_instance"))
+
+            return self._make_a10_device_instance_dict(instance)

--- a/a10_neutron_lbaas/neutron_ext/db/a10_device_instance.py
+++ b/a10_neutron_lbaas/neutron_ext/db/a10_device_instance.py
@@ -118,3 +118,9 @@ class A10DeviceInstanceDbMixin(common_db_mixin.CommonDbMixin,
                       (id))
             instance = self._get_by_id(context, models.A10DeviceInstance, id)
             context.session.delete(instance)
+
+    def update_a10_device_instance(self, context, a10_device_instance):
+        with context.session.begin(subtransactions=True):
+            instance = self._get_by_id(context, models.A10DeviceInstance,
+                                       a10_device_instance.get("id"))
+            context.session.update(instance)

--- a/a10_neutron_lbaas/neutron_ext/db/a10_device_instance.py
+++ b/a10_neutron_lbaas/neutron_ext/db/a10_device_instance.py
@@ -118,4 +118,3 @@ class A10DeviceInstanceDbMixin(common_db_mixin.CommonDbMixin,
                       (id))
             instance = self._get_by_id(context, models.A10DeviceInstance, id)
             context.session.delete(instance)
-

--- a/a10_neutron_lbaas/neutron_ext/extensions/a10DeviceInstance.py
+++ b/a10_neutron_lbaas/neutron_ext/extensions/a10DeviceInstance.py
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 # Copyright 2015,  A10 Networks
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -118,4 +119,8 @@ class A10DeviceInstancePluginBase(service_base.ServicePluginBase):
 
     @abc.abstractmethod
     def get_a10_device_instance(self, context, id, fields=None):
+        pass
+
+    @abc.abstractmethod
+    def delete_a10_device_instance(self, context, id):
         pass

--- a/a10_neutron_lbaas/neutron_ext/extensions/a10DeviceInstance.py
+++ b/a10_neutron_lbaas/neutron_ext/extensions/a10DeviceInstance.py
@@ -1,4 +1,3 @@
-<<<<<<< HEAD
 # Copyright 2015,  A10 Networks
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/a10_neutron_lbaas/neutron_ext/extensions/a10DeviceInstance.py
+++ b/a10_neutron_lbaas/neutron_ext/extensions/a10DeviceInstance.py
@@ -17,7 +17,9 @@ import six
 
 from a10_openstack_lib.resources import a10_device_instance
 
+
 from neutron.api import extensions
+from neutron.api.v2 import attributes as nattributes
 from neutron.api.v2 import resource_helper
 from neutron.services import service_base
 
@@ -58,7 +60,7 @@ class A10DeviceInstance(extensions.ExtensionDescriptor):
         """Returns external resources."""
         my_plurals = resource_helper.build_plural_mappings(
             {}, RESOURCE_ATTRIBUTE_MAP)
-        attributes.PLURALS.update(my_plurals)
+        nattributes.PLURALS.update(my_plurals)
         attr_map = RESOURCE_ATTRIBUTE_MAP
         resources = resource_helper.build_resource_info(my_plurals,
                                                         attr_map,

--- a/a10_neutron_lbaas/neutron_ext/extensions/a10DeviceInstance.py
+++ b/a10_neutron_lbaas/neutron_ext/extensions/a10DeviceInstance.py
@@ -125,3 +125,7 @@ class A10DeviceInstancePluginBase(service_base.ServicePluginBase):
     @abc.abstractmethod
     def delete_a10_device_instance(self, context, id):
         pass
+
+    @abc.abstractmethod
+    def update_a10_device_instance(self, context, instance):
+        pass

--- a/a10_neutron_lbaas/neutron_ext/extensions/a10DeviceInstance.py
+++ b/a10_neutron_lbaas/neutron_ext/extensions/a10DeviceInstance.py
@@ -127,5 +127,5 @@ class A10DeviceInstancePluginBase(service_base.ServicePluginBase):
         pass
 
     @abc.abstractmethod
-    def update_a10_device_instance(self, context, instance):
+    def update_a10_device_instance(self, context, id, a10_device_instance):
         pass

--- a/a10_neutron_lbaas/neutron_ext/services/a10_device_instance/plugin.py
+++ b/a10_neutron_lbaas/neutron_ext/services/a10_device_instance/plugin.py
@@ -20,6 +20,7 @@ import a10_neutron_lbaas.neutron_ext.db.a10_device_instance as a10_device_instan
 import a10_neutron_lbaas.vthunder.instance_manager as instance_manager
 import a10_neutron_lbaas.vthunder.keystone as keystone
 
+
 LOG = logging.getLogger(__name__)
 
 
@@ -37,24 +38,22 @@ class A10DeviceInstancePlugin(a10_device_instance.A10DeviceInstanceDbMixin):
 
     def create_a10_device_instance(self, context, a10_device_instance):
         LOG.debug("A10DeviceInstancePlugin.create(): a10_device_instance=%s", a10_device_instance)
-        import pdb
-        pdb.set_trace()
-
         # Attempt to create instance using neutron context
         config = a10_config.A10Config()
         ks = keystone.KeystoneFromContext(config, context)
         # TODO(mdurrant) - Move this logic into instance manager. Pass in context, get thing.
         imgr = instance_manager.InstanceManager._factory_with_service_tenant(config, ks)
-
         vth_config = config.get_vthunder_config()
-        instance = imgr._build_server_with_defaults(context, vth_config)
+        # #TODO(mdurrant) This is in a constant, use it
+        # Pass the member dict to avoid unnecessary transforms.
+        instance = imgr.build_server_with_defaults(
+            a10_device_instance.get("a10_device_instance"), vth_config)
         instance = imgr.create_instance(instance)
         nova_instance_id = instance.get("nova_instance_id")
-        context["nova_instance_id"] = nova_instance_id
+        a10_device_instance.get("a10_device_instance")["nova_instance_id"] = nova_instance_id
 
         # If success, return the created DB record
         # Else, raise an exception because that's what we would do anyway
-
         return super(A10DeviceInstancePlugin, self).create_a10_device_instance(context,
                                                                                a10_device_instance)
 

--- a/a10_neutron_lbaas/neutron_ext/services/a10_device_instance/plugin.py
+++ b/a10_neutron_lbaas/neutron_ext/services/a10_device_instance/plugin.py
@@ -66,15 +66,17 @@ class A10DeviceInstancePlugin(a10_device_instance.A10DeviceInstanceDbMixin):
         return super(A10DeviceInstancePlugin, self).get_a10_device_instance(context,
                                                                             id,
                                                                             fields=fields)
-    # def update_a10_device_instance(self, context, id, a10_device_instance):
-    #     LOG.debug(
-    #         "A10DeviceInstancePlugin.update_a10_device_instance(): id=%s, instance=%s",
-    #         id,
-    #         a10_device_instance)
-    #     return super(A10DeviceInstancePlugin, self).a10_device_instance(
-    #         context,
-    #         id,
-    #         a10_device_instance)
+
+    def update_a10_device_instance(self, context, id, a10_device_instance):
+        LOG.debug(
+            "A10DeviceInstancePlugin.update_a10_device_instance(): id=%s, instance=%s",
+            id,
+            a10_device_instance)
+
+        return super(A10DeviceInstancePlugin, self).a10_device_instance(
+            context,
+            id,
+            a10_device_instance)
 
     def delete_a10_device_instance(self, context, id):
         LOG.debug("A10DeviceInstancePlugin.delete(): id=%s", id)

--- a/a10_neutron_lbaas/neutron_ext/services/a10_device_instance/plugin.py
+++ b/a10_neutron_lbaas/neutron_ext/services/a10_device_instance/plugin.py
@@ -15,9 +15,10 @@
 from oslo_log import log as logging
 
 import a10_neutron_lbaas.a10_config as a10_config
-import a10_neutron_lbaas.neutron_ext.common.constants as constants
+from a10_neutron_lbaas.neutron_ext.common import constants
 import a10_neutron_lbaas.neutron_ext.db.a10_device_instance as a10_device_instance
 import a10_neutron_lbaas.vthunder.instance_manager as instance_manager
+from a10_openstack_lib.resources import a10_device_instance as resources
 
 
 LOG = logging.getLogger(__name__)
@@ -43,7 +44,8 @@ class A10DeviceInstancePlugin(a10_device_instance.A10DeviceInstanceDbMixin):
         imgr = instance_manager.InstanceManager.from_config(config, context)
         # #TODO(mdurrant) This is in a constant, use it
         # Pass the member dict to avoid unnecessary transforms.
-        dev_instance = a10_device_instance.get("a10_device_instance")
+
+        dev_instance = a10_device_instance.get(resources.RESOURCE)
 
         instance = imgr.build_server_with_defaults(dev_instance, vth_config)
         instance = imgr.create_instance(instance)

--- a/a10_neutron_lbaas/neutron_ext/services/a10_device_instance/plugin.py
+++ b/a10_neutron_lbaas/neutron_ext/services/a10_device_instance/plugin.py
@@ -14,8 +14,11 @@
 
 from oslo_log import log as logging
 
+import a10_neutron_lbaas.a10_config as a10_config
 import a10_neutron_lbaas.neutron_ext.common.constants as constants
 import a10_neutron_lbaas.neutron_ext.db.a10_device_instance as a10_device_instance
+import a10_neutron_lbaas.vthunder.instance_manager as instance_manager
+import a10_neutron_lbaas.vthunder.keystone as keystone
 
 LOG = logging.getLogger(__name__)
 
@@ -34,6 +37,24 @@ class A10DeviceInstancePlugin(a10_device_instance.A10DeviceInstanceDbMixin):
 
     def create_a10_device_instance(self, context, a10_device_instance):
         LOG.debug("A10DeviceInstancePlugin.create(): a10_device_instance=%s", a10_device_instance)
+        import pdb
+        pdb.set_trace()
+
+        # Attempt to create instance using neutron context
+        config = a10_config.A10Config()
+        ks = keystone.KeystoneFromContext(config, context)
+        # TODO(mdurrant) - Move this logic into instance manager. Pass in context, get thing.
+        imgr = instance_manager.InstanceManager._factory_with_service_tenant(config, ks)
+
+        vth_config = config.get_vthunder_config()
+        instance = imgr._build_server_with_defaults(context, vth_config)
+        instance = imgr.create_instance(instance)
+        nova_instance_id = instance.get("nova_instance_id")
+        context["nova_instance_id"] = nova_instance_id
+
+        # If success, return the created DB record
+        # Else, raise an exception because that's what we would do anyway
+
         return super(A10DeviceInstancePlugin, self).create_a10_device_instance(context,
                                                                                a10_device_instance)
 

--- a/a10_neutron_lbaas/neutron_ext/services/a10_device_instance/plugin.py
+++ b/a10_neutron_lbaas/neutron_ext/services/a10_device_instance/plugin.py
@@ -18,7 +18,6 @@ import a10_neutron_lbaas.a10_config as a10_config
 import a10_neutron_lbaas.neutron_ext.common.constants as constants
 import a10_neutron_lbaas.neutron_ext.db.a10_device_instance as a10_device_instance
 import a10_neutron_lbaas.vthunder.instance_manager as instance_manager
-import a10_neutron_lbaas.vthunder.keystone as keystone
 
 
 LOG = logging.getLogger(__name__)
@@ -44,11 +43,15 @@ class A10DeviceInstancePlugin(a10_device_instance.A10DeviceInstanceDbMixin):
         imgr = instance_manager.InstanceManager.from_config(config, context)
         # #TODO(mdurrant) This is in a constant, use it
         # Pass the member dict to avoid unnecessary transforms.
-        instance = imgr.build_server_with_defaults(
-            a10_device_instance.get("a10_device_instance"), vth_config)
+        dev_instance = a10_device_instance.get("a10_device_instance")
+
+        instance = imgr.build_server_with_defaults(dev_instance, vth_config)
         instance = imgr.create_instance(instance)
+        host_ip = instance.get("ip_address")
         nova_instance_id = instance.get("nova_instance_id")
-        a10_device_instance.get("a10_device_instance")["nova_instance_id"] = nova_instance_id
+        # things we don't know until the instance is created.
+        dev_instance["host"] = host_ip
+        dev_instance["nova_instance_id"] = nova_instance_id
 
         # If success, return the created DB record
         # Else, raise an exception because that's what we would do anyway
@@ -78,7 +81,6 @@ class A10DeviceInstancePlugin(a10_device_instance.A10DeviceInstanceDbMixin):
                                                                                 id)
         nova_instance_id = instance.get("nova_instance_id")
         config = a10_config.A10Config()
-        vth_config = config.get_vthunder_config()
         imgr = instance_manager.InstanceManager.from_config(config, context)
         imgr.delete_instance(nova_instance_id)
 

--- a/a10_neutron_lbaas/neutron_ext/services/a10_device_instance/plugin.py
+++ b/a10_neutron_lbaas/neutron_ext/services/a10_device_instance/plugin.py
@@ -43,7 +43,6 @@ class A10DeviceInstancePlugin(a10_device_instance.A10DeviceInstanceDbMixin):
         return super(A10DeviceInstancePlugin, self).get_a10_device_instance(context,
                                                                             id,
                                                                             fields=fields)
-
     # def update_a10_device_instance(self, context, id, a10_device_instance):
     #     LOG.debug(
     #         "A10DeviceInstancePlugin.update_a10_device_instance(): id=%s, instance=%s",
@@ -54,6 +53,6 @@ class A10DeviceInstancePlugin(a10_device_instance.A10DeviceInstanceDbMixin):
     #         id,
     #         a10_device_instance)
 
-    # def delete_a10_device_instance(self, context, id):
-    #     LOG.debug("A10DeviceInstancePlugin.delete(): id=%s", id)
-    #     return super(A10DeviceInstancePlugin, self).delete_a10_device_instance(context, id)
+    def delete_a10_device_instance(self, context, id):
+        LOG.debug("A10DeviceInstancePlugin.delete(): id=%s", id)
+        return super(A10DeviceInstancePlugin, self).delete_a10_device_instance(context, id)

--- a/a10_neutron_lbaas/neutron_ext/services/a10_device_instance/plugin.py
+++ b/a10_neutron_lbaas/neutron_ext/services/a10_device_instance/plugin.py
@@ -77,7 +77,7 @@ class A10DeviceInstancePlugin(a10_device_instance.A10DeviceInstanceDbMixin):
             id,
             a10_device_instance)
 
-        return super(A10DeviceInstancePlugin, self).a10_device_instance(
+        return super(A10DeviceInstancePlugin, self).update_a10_device_instance(
             context,
             id,
             a10_device_instance)

--- a/a10_neutron_lbaas/tests/db/neutron_ext/services/a10_device_instance/test_plugin.py
+++ b/a10_neutron_lbaas/tests/db/neutron_ext/services/a10_device_instance/test_plugin.py
@@ -50,7 +50,7 @@ class TestPlugin(test_a10_device_instance.TestA10DeviceInstanceDbMixin):
 
     def test_create_calls_instance_manager(self):
         self.target.create_a10_device_instance(self.context, self._build_instance())
-        self.assertTrue(self.instance_manager.create_instance.called)
+        self.assertTrue(self.instance_manager.create_device_instance.called)
 
     def test_delete_calls_instance_manager(self):
         self.target.delete_a10_device_instance(self.context, 1)

--- a/a10_neutron_lbaas/tests/db/neutron_ext/services/a10_device_instance/test_plugin.py
+++ b/a10_neutron_lbaas/tests/db/neutron_ext/services/a10_device_instance/test_plugin.py
@@ -17,13 +17,42 @@ from a10_neutron_lbaas.tests.db.neutron_ext.db import test_a10_device_instance
 import a10_neutron_lbaas.neutron_ext.common.constants as constants
 import a10_neutron_lbaas.neutron_ext.services.a10_device_instance.plugin as plugin
 
+import a10_neutron_lbaas.vthunder.instance_manager as instance_manager
+
+import mock
+
 
 class TestPlugin(test_a10_device_instance.TestA10DeviceInstanceDbMixin):
 
     def setUp(self):
         super(TestPlugin, self).setUp()
         self.plugin = plugin.A10DeviceInstancePlugin()
+        self.target = self.plugin
+        self.context = mock.MagicMock(tenant_id="MY_FAKE_TENANT")
+        self.instance_manager = mock.MagicMock()
+        instance_manager.InstanceManager.from_config = mock.MagicMock(
+            return_value=self.instance_manager)
+
+    def _build_instance(self):
+        return {
+            "a10_device_instance": {
+                "name": "asdf",
+                "host": "10.10.42.42",
+                "image": "MY_FAKE_IMAGE",
+                "flavor": "MY_FAKE_FLAVOR",
+                "networks": ["this_network", "that_network"],
+            }
+        }
 
     def test_supported_extension_aliases(self):
         sea = self.plugin.supported_extension_aliases
         self.assertEqual([constants.A10_DEVICE_INSTANCE_EXT], sea)
+
+    def test_create_calls_instance_manager(self):
+        self.target.create_a10_device_instance(self.context, self._build_instance())
+        self.assertTrue(self.instance_manager.create_instance.called)
+
+    def test_delete_calls_instance_manager(self):
+        self.target.delete_a10_device_instance(self.context, 1)
+        delete_call = self.instance_manager.delete_instance
+        self.assertTrue(delete_call.called)

--- a/a10_neutron_lbaas/vthunder/instance_manager.py
+++ b/a10_neutron_lbaas/vthunder/instance_manager.py
@@ -382,9 +382,14 @@ class InstanceManager(object):
     def build_server_with_defaults(self, server, vthunder_config):
         copy_keys = [("image", "glance_image"),
                      ("flavor", "nova_flavor"),
+                     ("username", "username"),
+                     ("password", "password"),
+                     ("api_version", "api_version"),
+                     ("port", "port"),
+                     ("protocol", "protocol")
                      ]
 
-        resources.remove_resources_not_specified(server)
+        resources.remove_attributes_not_specified(server)
 
         for server_key, config_key in copy_keys:
             # if the server doesn't have this attribute configured, set it from default

--- a/a10_neutron_lbaas/vthunder/instance_manager.py
+++ b/a10_neutron_lbaas/vthunder/instance_manager.py
@@ -17,6 +17,8 @@ import pprint
 import time
 import uuid
 
+import glanceclient.client as glance_client
+
 import neutronclient.neutron.client as neutron_client
 
 import novaclient.client as nova_client
@@ -35,8 +37,8 @@ LOG = logging.getLogger(__name__)
 CREATE_TIMEOUT = 900
 
 # TODO(mdurrant) - These may need to go into a configuration file.
-GLANCE_VERSION = 2
-KEYSTONE_VERSION = "2.0"
+GLANCE_VERSION = 2.1
+KEYSTONE_VERSION = "3.0"
 NOVA_VERSION = "2.1"
 NEUTRON_VERSION = "2.0"
 OS_INTERFACE_URLS = ["public", "publicURL"]
@@ -86,6 +88,8 @@ class InstanceManager(object):
             nova_version, session=self._ks_session)
         self._neutron_api = neutron_api or neutron_client.Client(
             NEUTRON_VERSION, session=self._ks_session)
+        self._glance_api = glance_api or glance_client.Client(
+            GLANCE_VERSION, session=self._ks_session)
 
     @classmethod
     def _factory_with_service_tenant(cls, config, user_keystone_session):
@@ -245,7 +249,7 @@ class InstanceManager(object):
                       ((hasattr(x, "name") and x.name is not None and identifier in x.name)
                        or (hasattr(x, "id") and x.id == identifier)))
         try:
-            images = self._nova_api.images.list()
+            images = self._glance_api.images.list()
         except Exception as ex:
             raise a10_ex.ImageNotFoundError(
                 "Unable to retrieve images from nova.  Error %s" % (ex))

--- a/a10_neutron_lbaas/vthunder/instance_manager.py
+++ b/a10_neutron_lbaas/vthunder/instance_manager.py
@@ -12,14 +12,13 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-import copy
 import logging
 import pprint
 import time
 import uuid
 
-import neutronclient.neutron.client as neutron_client
 import neutron_lib.constants as neutron_const
+import neutronclient.neutron.client as neutron_client
 
 import novaclient.client as nova_client
 import novaclient.exceptions as nova_exceptions
@@ -389,7 +388,7 @@ class InstanceManager(object):
         for server_key, config_key in copy_keys:
             # if the server doesn't have this attribute configured, set it from default
             # Sentinel is the value set by the API when it's unspecified.
-            if not server_key in server or type(server[server_key]) == neutron_const.Sentinel:
+            if server_key not in server or type(server[server_key]) == neutron_const.Sentinel:
                 server[server_key] = vthunder_config.get(config_key)
         rv = self._build_server(server)
 

--- a/a10_neutron_lbaas/vthunder/instance_manager.py
+++ b/a10_neutron_lbaas/vthunder/instance_manager.py
@@ -388,8 +388,10 @@ class InstanceManager(object):
 
         for server_key, config_key in copy_keys:
             # if the server doesn't have this attribute configured, set it from default
+            # Sentinel is the value set by the API when it's unspecified.
             if not server_key in server or type(server[server_key]) == neutron_const.Sentinel:
                 server[server_key] = vthunder_config.get(config_key)
+        rv = self._build_server(server)
 
         # Returning this as an array makes further concatenation easier.
         mgmt_network = [server.get("mgmt_network",
@@ -397,8 +399,6 @@ class InstanceManager(object):
         data_networks = server.get("data_networks",
                                    vthunder_config.get("vthunder_data_networks"))
         networks = mgmt_network + data_networks
-        rv = self._build_server(server)
-
         rv["networks"] = networks
 
         return rv

--- a/a10_neutron_lbaas/vthunder/instance_manager.py
+++ b/a10_neutron_lbaas/vthunder/instance_manager.py
@@ -23,7 +23,6 @@ import novaclient.client as nova_client
 import novaclient.exceptions as nova_exceptions
 
 import a10_neutron_lbaas.a10_exceptions as a10_ex
-from a10_neutron_lbaas.neutron_ext.common import resources
 import a10_neutron_lbaas.vthunder.keystone as a10_keystone
 
 

--- a/a10_neutron_lbaas/vthunder/instance_manager.py
+++ b/a10_neutron_lbaas/vthunder/instance_manager.py
@@ -379,34 +379,6 @@ class InstanceManager(object):
         network_id = subnet["subnet"]["network_id"]
         return self.plumb_instance(instance_id, network_id, allowed_ips, wrong_ips=wrong_ips)
 
-    def build_server_with_defaults(self, server, vthunder_config):
-        copy_keys = [("image", "glance_image"),
-                     ("flavor", "nova_flavor"),
-                     ("username", "username"),
-                     ("password", "password"),
-                     ("api_version", "api_version"),
-                     ("port", "port"),
-                     ("protocol", "protocol")
-                     ]
-
-        resources.remove_attributes_not_specified(server)
-
-        for server_key, config_key in copy_keys:
-            # if the server doesn't have this attribute configured, set it from default
-            if server_key not in server:
-                server[server_key] = vthunder_config.get(config_key)
-        rv = self._build_server(server)
-
-        # Returning this as an array makes further concatenation easier.
-        mgmt_network = [server.get("mgmt_network",
-                                   vthunder_config.get("vthunder_management_network"))]
-        data_networks = server.get("data_networks",
-                                   vthunder_config.get("vthunder_data_networks"))
-        networks = mgmt_network + data_networks
-        rv["networks"] = networks
-
-        return rv
-
 
 def distinct_dicts(dicts):
     hashable = map(lambda x: tuple(sorted(x.items())), dicts)

--- a/a10_neutron_lbaas/vthunder/instance_manager.py
+++ b/a10_neutron_lbaas/vthunder/instance_manager.py
@@ -17,14 +17,13 @@ import pprint
 import time
 import uuid
 
-import neutron_lib.constants as neutron_const
 import neutronclient.neutron.client as neutron_client
 
 import novaclient.client as nova_client
 import novaclient.exceptions as nova_exceptions
 
 import a10_neutron_lbaas.a10_exceptions as a10_ex
-
+from a10_neutron_lbaas.neutron_ext.common import resources
 import a10_neutron_lbaas.vthunder.keystone as a10_keystone
 
 
@@ -385,10 +384,11 @@ class InstanceManager(object):
                      ("flavor", "nova_flavor"),
                      ]
 
+        resources.remove_resources_not_specified(server)
+
         for server_key, config_key in copy_keys:
             # if the server doesn't have this attribute configured, set it from default
-            # Sentinel is the value set by the API when it's unspecified.
-            if server_key not in server or type(server[server_key]) == neutron_const.Sentinel:
+            if server_key not in server:
                 server[server_key] = vthunder_config.get(config_key)
         rv = self._build_server(server)
 

--- a/a10_neutron_lbaas/vthunder/keystone.py
+++ b/a10_neutron_lbaas/vthunder/keystone.py
@@ -91,7 +91,27 @@ class KeystoneFromContext(KeystoneBase):
         if int(ks_version) == 2:
             auth = v2.Token(auth_url=auth_url, token=auth_token, tenant_id=tenant_id)
         elif int(ks_version) == 3:
-            auth = v3.Token(auth_url=auth_url, token=auth_token, tenant_id=tenant_id)
+            auth = v3.Token(auth_url=auth_url, token=auth_token, project_id=tenant_id)
+        else:
+            raise a10_ex.InvalidConfig('keystone version must be protovol version 2 or 3')
+
+        return self._get_keystone_stuff(ks_version, auth)
+
+
+class KeystoneFromHorizonRequest(KeystoneBase):
+    def __init__(self, a10_config, request):
+        self.request = request
+        (self._session, self._keystone_client) = self._get_keystone_token(
+            ks_version=a10_config.get('keystone_version'),
+            auth_url=a10_config.get('keystone_auth_url'),
+            auth_token=request.user.token.unscoped_token,
+            tenant_id=request.user.tenant_id)
+
+    def _get_keystone_token(self, ks_version, auth_url, auth_token, tenant_id):
+        if int(ks_version) == 2:
+            auth = v2.Token(auth_url=auth_url, token=auth_token, tenant_id=tenant_id)
+        elif int(ks_version) == 3:
+            auth = v3.Token(auth_url=auth_url, token=auth_token, project_id=tenant_id)
         else:
             raise a10_ex.InvalidConfig('keystone version must be protovol version 2 or 3')
 

--- a/a10_neutron_lbaas/vthunder/keystone.py
+++ b/a10_neutron_lbaas/vthunder/keystone.py
@@ -96,23 +96,3 @@ class KeystoneFromContext(KeystoneBase):
             raise a10_ex.InvalidConfig('keystone version must be protovol version 2 or 3')
 
         return self._get_keystone_stuff(ks_version, auth)
-
-
-class KeystoneFromHorizonRequest(KeystoneBase):
-    def __init__(self, a10_config, request):
-        self.request = request
-        (self._session, self._keystone_client) = self._get_keystone_token(
-            ks_version=a10_config.get('keystone_version'),
-            auth_url=a10_config.get('keystone_auth_url'),
-            auth_token=request.user.token.unscoped_token,
-            tenant_id=request.user.tenant_id)
-
-    def _get_keystone_token(self, ks_version, auth_url, auth_token, tenant_id):
-        if int(ks_version) == 2:
-            auth = v2.Token(auth_url=auth_url, token=auth_token, tenant_id=tenant_id)
-        elif int(ks_version) == 3:
-            auth = v3.Token(auth_url=auth_url, token=auth_token, project_id=tenant_id)
-        else:
-            raise a10_ex.InvalidConfig('keystone version must be protovol version 2 or 3')
-
-        return self._get_keystone_stuff(ks_version, auth)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ debtcollector
 # Many of our requirements have to be the same as the underlying neutron,
 # so while we will list the ones used explicity here, we will not necessarily
 # specifiy versions
-
+neutron-lib>=0.4.0
 python-glanceclient>=0.9.0  # icehouse min
 python-keystoneclient>=0.7.0  # icehouse min
 python-novaclient  # implicit from neutron

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ debtcollector
 # Many of our requirements have to be the same as the underlying neutron,
 # so while we will list the ones used explicity here, we will not necessarily
 # specifiy versions
-neutron-lib>=0.4.0
 python-glanceclient>=0.9.0  # icehouse min
 python-keystoneclient>=0.7.0  # icehouse min
 python-novaclient  # implicit from neutron

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,6 +5,7 @@ mox
 mox3
 nose
 nose-exclude
+oslotest
 pymysql
 # TODO(dougwig) -- can we remove this?
 -e git+https://github.com/openstack/neutron#egg=neutron

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,6 +5,7 @@ mox
 mox3
 nose
 nose-exclude
+# API and DB test bases use oslotest
 oslotest
 pymysql
 # TODO(dougwig) -- can we remove this?


### PR DESCRIPTION
- nova instance ID returned by a10 device instance service
- added nova_instance_id migration
- Create Keystone context from Horizon request factory method
- Windows -> UNIX line endings
