### PR TITLE
service_group_lb_method now uses constants for v21/v30

### DIFF
--- a/a10_neutron_lbaas/acos/openstack_mappings.py
+++ b/a10_neutron_lbaas/acos/openstack_mappings.py
@@ -29,34 +29,7 @@ def service_group_lb_method(c, os_method):
     lb_methods = {
         'ROUND_ROBIN': z.ROUND_ROBIN,
         'LEAST_CONNECTIONS': z.LEAST_CONNECTION,
-        'SOURCE_IP': z.WEIGHTED_LEAST_CONNECTION,
-        'WEIGHTED_ROUND_ROBIN': z.WEIGHTED_ROUND_ROBIN,
-        'WEIGHTED_LEAST_CONNECTION': z.WEIGHTED_LEAST_CONNECTION,
-        'LEAST_CONNECTION_ON_SERVICE_PORT':
-            z.LEAST_CONNECTION_ON_SERVICE_PORT,
-        'WEIGHTED_LEAST_CONNECTION_ON_SERVICE_PORT':
-            z.WEIGHTED_LEAST_CONNECTION_ON_SERVICE_PORT,
-        'FAST_RESPONSE_TIME': z.FAST_RESPONSE_TIME,
-        'LEAST_REQUEST': z.LEAST_REQUEST,
-        'STRICT_ROUND_ROBIN': z.STRICT_ROUND_ROBIN,
-        'STATELESS_SOURCE_IP_HASH': z.STATELESS_SOURCE_IP_HASH,
-        'STATELESS_DESTINATION_IP_HASH': z.STATELESS_DESTINATION_IP_HASH,
-        'STATELESS_SOURCE_DESTINATION_IP_HASH':
-            z.STATELESS_SOURCE_DESTINATION_IP_HASH,
-        'STATELESS_PER_PACKET_ROUND_ROBIN':
-            z.STATELESS_PER_PACKET_ROUND_ROBIN,
-    }
-    return lb_methods[os_method]
-
-
-# This is duplicated because v1/v2 have different mappings.
-# TODO(mdurrant) Refactor this into a dictionary that encapsulates v1/v2 differences.
-def service_group_lb_method_v2(c, os_method):
-    z = c.client.slb.service_group
-    lb_methods = {
-        'ROUND_ROBIN': z.ROUND_ROBIN,
-        'LEAST_CONNECTIONS': z.LEAST_CONNECTION,
-        'SOURCE_IP': 'src-ip-hash',
+        'SOURCE_IP': z.SOURCE_IP_HASH,
         'WEIGHTED_ROUND_ROBIN': z.WEIGHTED_ROUND_ROBIN,
         'WEIGHTED_LEAST_CONNECTION': z.WEIGHTED_LEAST_CONNECTION,
         'LEAST_CONNECTION_ON_SERVICE_PORT':

--- a/a10_neutron_lbaas/tests/unit/v2/acos/test_openstack_mapping.py
+++ b/a10_neutron_lbaas/tests/unit/v2/acos/test_openstack_mapping.py
@@ -22,6 +22,7 @@ class TestA10Openstack(test_base.UnitTestBase):
 
     def test_source_ip_v2(self):
         mock_client = mock.Mock()
-        expected = 'src-ip-hash'
-        actual = target.service_group_lb_method_v2(mock_client, 'SOURCE_IP')
+        mock_client.client.slb.service_group.SOURCE_IP_HASH = 'SOURCE_IP'
+        expected = mock_client.client.slb.service_group.SOURCE_IP_HASH
+        actual = target.service_group_lb_method(mock_client, 'SOURCE_IP')
         self.assertEqual(expected, actual)

--- a/a10_neutron_lbaas/v2/handler_pool.py
+++ b/a10_neutron_lbaas/v2/handler_pool.py
@@ -32,7 +32,7 @@ class PoolHandler(handler_base_v2.HandlerBaseV2):
         set_method(
             self._meta_name(pool),
             protocol=openstack_mappings.service_group_protocol(c, pool.protocol),
-            lb_method=openstack_mappings.service_group_lb_method_v2(c, pool.lb_algorithm),
+            lb_method=openstack_mappings.service_group_lb_method(c, pool.lb_algorithm),
             axapi_args=args)
 
         # session persistence might need a vport update


### PR DESCRIPTION
* Updated tests to reflect constant changes
* No more separate v2 lb_method