### PR TITLE
Fix Barbican support in Mitaka

### DIFF
--- a/a10_neutron_lbaas/v2/handler_listener.py
+++ b/a10_neutron_lbaas/v2/handler_listener.py
@@ -66,7 +66,8 @@ class ListenerHandler(handler_base_v2.HandlerBaseV2):
         # Try Barbican first.  TERMINATED HTTPS requires a default TLS container ID that is
         # checked by the API so we can't fake it out.
         if listener.protocol and listener.protocol == constants.PROTOCOL_TERMINATED_HTTPS:
-            if self._set_terminated_https_values(listener, c, cert_data):
+            if self._set_terminated_https_values(listener, c,
+                                                 context, cert_data):
                 templates["client_ssl"] = {}
                 template_name = str(cert_data.get('template_name') or '')
                 key_passphrase = str(cert_data.get('key_pass') or '')
@@ -164,7 +165,7 @@ class ListenerHandler(handler_base_v2.HandlerBaseV2):
         except acos_errors.Exists:
             pass
 
-    def _set_terminated_https_values(self, listener, c, cert_data):
+    def _set_terminated_https_values(self, listener, c, context, cert_data):
         is_success = False
         container = None
 
@@ -173,7 +174,9 @@ class ListenerHandler(handler_base_v2.HandlerBaseV2):
         # if there's a barbican container ID, check there.
         if c_id:
             try:
-                container = self.barbican_client.get_certificate(c_id, check_only=True)
+                container = self.barbican_client.get_certificate(
+                    context.project_id, c_id, None, check_only=True
+                )
             except Exception as ex:
                 container = None
                 LOG.error("Exception encountered retrieving TLS Container %s" % c_id)

--- a/a10_neutron_lbaas/v2/wrapper_certmgr.py
+++ b/a10_neutron_lbaas/v2/wrapper_certmgr.py
@@ -20,8 +20,8 @@ class CertManagerWrapper(object):
         else:
             self.certmgr = handler.neutron.bcm_factory()
 
-    def get_certificate(self, container_id, **kwargs):
-        return self.certmgr.get_cert(container_id, **kwargs)
+    def get_certificate(self, project_id, cert_ref, resource_ref, **kwargs):
+        return self.certmgr.get_cert(project_id, cert_ref, resource_ref, **kwargs)
 
     def store_cert(self, certificate, private_key, intermediates=None,
                    private_key_passphrase=None, expiration=None,


### PR DESCRIPTION
The get_cert call was changed in Mitaka and needs to be updated accordingly in the a10 module.
https://github.com/openstack/neutron-lbaas/blob/stable/mitaka/neutron_lbaas/common/cert_manager/barbican_cert_manager.py#L153
https://github.com/openstack/neutron-lbaas/blob/master/neutron_lbaas/common/cert_manager/cert_manager.py#L72