### PR TITLE
Mitaka Barbican Compatibility

### DIFF
--- a/a10_neutron_lbaas/tests/unit/v2/test_wrapper_certmgr.py
+++ b/a10_neutron_lbaas/tests/unit/v2/test_wrapper_certmgr.py
@@ -1,0 +1,43 @@
+# Copyright 2017, A10 Networks
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import mock
+
+from neutron_lbaas.common.cert_manager import cert_manager
+
+from a10_neutron_lbaas.tests import test_case
+from a10_neutron_lbaas.v2 import wrapper_certmgr
+
+
+class TestCertManagerWrapper(test_case.TestCase):
+
+    def setUp(self, **kwargs):
+        super(TestCertManagerWrapper, self).setUp(**kwargs)
+
+        certmgr = mock.create_autospec(cert_manager.CertManager)
+        self.target = wrapper_certmgr.CertManagerWrapper(certmgr=certmgr)
+
+    def test_get_certificate_type_checks(self):
+        self.target.get_certificate('fake-container-id',
+                                    project_id='fake-project-id',
+                                    check_only=True)
+
+    def test_store_cert_type_checks(self):
+        self.target.store_cert('fake-certificate',
+                               'fake-private-key',
+                               project_id='fake-project-id')
+
+    def test_delete_cert_type_checks(self):
+        self.target.delete_cert('fake-certificate-id',
+                                project_id='fake-project-id')

--- a/a10_neutron_lbaas/v2/handler_listener.py
+++ b/a10_neutron_lbaas/v2/handler_listener.py
@@ -174,7 +174,8 @@ class ListenerHandler(handler_base_v2.HandlerBaseV2):
         # if there's a barbican container ID, check there.
         if c_id:
             try:
-                container = self.barbican_client.get_certificate(c_id, check_only=True)
+                container = self.barbican_client.get_certificate(c_id, check_only=True,
+                                                                 project_id=c.tenant_id)
             except Exception as ex:
                 container = None
                 LOG.error("Exception encountered retrieving TLS Container %s" % c_id)

--- a/a10_neutron_lbaas/v2/handler_listener.py
+++ b/a10_neutron_lbaas/v2/handler_listener.py
@@ -116,7 +116,8 @@ class ListenerHandler(handler_base_v2.HandlerBaseV2):
                 c.client.slb.template.client_ssl.create(
                     template_name,
                     cert=cert_filename,
-                    key=key_filename)
+                    key=key_filename,
+                    passphrase=key_passphrase)
             except acos_errors.Exists:
                 c.client.slb.template.client_ssl.update(template_name, cert=cert_filename,
                                                         key=key_filename, passphrase=key_passphrase)
@@ -129,11 +130,13 @@ class ListenerHandler(handler_base_v2.HandlerBaseV2):
                     template_name,
                     cert_filename,
                     key_filename,
+                    passphrase=key_passphrase,
                     axapi_args=server_args)
             except acos_errors.Exists:
                 c.client.slb.template.server_ssl.update(template_name,
                                                         cert_filename,
                                                         key_filename,
+                                                        passphrase=key_passphrase,
                                                         axapi_args=server_args)
 
         try:

--- a/a10_neutron_lbaas/v2/wrapper_certmgr.py
+++ b/a10_neutron_lbaas/v2/wrapper_certmgr.py
@@ -20,17 +20,36 @@ class CertManagerWrapper(object):
         else:
             self.certmgr = handler.neutron.bcm_factory()
 
-    def get_certificate(self, container_id, **kwargs):
-        return self.certmgr.get_cert(container_id, **kwargs)
+    # neutron-lbaas barbican interface changed in Mitaka
+    # https://github.com/openstack/neutron-lbaas/commit/2228ef86ab7caf986a8608800d41add6cbd7f5f7
+
+    def get_certificate(self, container_id, project_id=None,
+                        resource_ref=None, **kwargs):
+        try:
+            return self.certmgr.get_cert(container_id, **kwargs)
+        except TypeError:
+            return self.certmgr.get_cert(project_id, container_id, resource_ref, **kwargs)
 
     def store_cert(self, certificate, private_key, intermediates=None,
                    private_key_passphrase=None, expiration=None,
-                   name='A10-LBaaS TLS Cert', **kwargs):
-        return self.certmgr.store_cert(certificate, private_key, intermediates=intermediates,
-                                       private_key_passphrase=private_key_passphrase,
-                                       expiration=expiration, name=name, kwargs=kwargs)
+                   name='A10-LBaaS TLS Cert',
+                   project_id=None, **kwargs):
+        try:
+            return self.certmgr.store_cert(certificate, private_key,
+                                           intermediates=intermediates,
+                                           private_key_passphrase=private_key_passphrase,
+                                           expiration=expiration, name=name, **kwargs)
+        except TypeError:
+            return self.certmgr.store_cert(project_id, certificate, private_key,
+                                           intermediates=intermediates,
+                                           private_key_passphrase=private_key_passphrase,
+                                           expiration=expiration, name=name, **kwargs)
 
     def delete_cert(self, cert_ref, service_name='A10-LBaaS', resource_ref=None,
-                    **kwargs):
-        return self.certmgr.delete_cert(cert_ref, service_name=service_name,
-                                        resource_ref=resource_ref, kwargs=kwargs)
+                    project_id=None, **kwargs):
+        try:
+            return self.certmgr.delete_cert(cert_ref, service_name=service_name,
+                                            resource_ref=resource_ref, **kwargs)
+        except TypeError:
+            return self.certmgr.delete_cert(project_id, cert_ref, resource_ref,
+                                            service_name=service_name, **kwargs)


### PR DESCRIPTION
 * Tests for the cert manager wrapper calling barbican client
 * Cert wrapper tries old way first, then the new way.
   "Better to ask for forgiveness than permission"
   Calling the new way first won't work.
 * Tests that the handler passes the project id to the cert
   manager wrapper

TODO: Fix key passphrase not being passed to acos client.