### PR TITLE
Fixed typo in default devices config

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ devices = {
         "password": "a10",
         "autosnat": True,
         "api_version": "3.0",
+    }
 }
 ```
 


### PR DESCRIPTION
We were missing a curly there at the end.