### PR TITLE
DO NOT MERGE: Hack to use src-ip-hash-only for SOURCE_IP pools

### DIFF
--- a/a10_neutron_lbaas/acos/openstack_mappings.py
+++ b/a10_neutron_lbaas/acos/openstack_mappings.py
@@ -29,7 +29,8 @@ def service_group_lb_method(c, os_method):
     lb_methods = {
         'ROUND_ROBIN': z.ROUND_ROBIN,
         'LEAST_CONNECTIONS': z.LEAST_CONNECTION,
-        'SOURCE_IP': z.SOURCE_IP_HASH,
+        # 'SOURCE_IP': z.SOURCE_IP_HASH,
+        'SOURCE_IP': z.SOURCE_IP_HASH_ONLY,
         'WEIGHTED_ROUND_ROBIN': z.WEIGHTED_ROUND_ROBIN,
         'WEIGHTED_LEAST_CONNECTION': z.WEIGHTED_LEAST_CONNECTION,
         'LEAST_CONNECTION_ON_SERVICE_PORT':


### PR DESCRIPTION
* Quick fix for sales engineer
Doing this via configuration is difficult given where things are defined and requires some delicate surgery to avoid making breaking changes.

----

DO NOT MERGE THIS. This is a quick fix for a surprisingly difficult problem and doing it via config is the best route. Other options are hooks though that is a bit dicey due to the possibility for human error.