### PR TITLE
TESTING: HM Port # Fix

### DIFF
--- a/a10_neutron_lbaas/neutron_ext/extensions/a10DeviceInstance.py
+++ b/a10_neutron_lbaas/neutron_ext/extensions/a10DeviceInstance.py
@@ -147,3 +147,7 @@ class A10DeviceInstancePluginBase(ServicePluginBase):
     @abc.abstractmethod
     def update_a10_device_instance(self, context, id, a10_device_instance):
         pass
+
+# This is a terrible way of solving a backwards compatibility bug for casing
+class A10DeviceInstance(A10deviceinstance):
+    pass

--- a/a10_neutron_lbaas/v2/handler_hm.py
+++ b/a10_neutron_lbaas/v2/handler_hm.py
@@ -33,6 +33,8 @@ class HealthMonitorHandler(handler_base_v2.HandlerBaseV2):
         url = None
         expect_code = None
         os_name = hm.name
+        port = kwargs.get("port") 
+
         if hm.type in ['HTTP', 'HTTPS']:
             method = hm.http_method
             url = hm.url_path
@@ -44,7 +46,7 @@ class HealthMonitorHandler(handler_base_v2.HandlerBaseV2):
 
         set_method(hm_name, openstack_mappings.hm_type(c, hm.type),
                    hm.delay, hm.timeout, hm.max_retries,
-                   method=method, url=url, expect_code=expect_code,
+                   method=method, url=url, expect_code=expect_code, port=port,
                    config_defaults=self._get_config_defaults(c, os_name),
                    axapi_args=args)
 
@@ -59,8 +61,8 @@ class HealthMonitorHandler(handler_base_v2.HandlerBaseV2):
 
     def _create(self, c, context, hm, **kwargs):
         try:
-            listener = self.neutron_ops.hm_get_listener(context, hm)
-            hm.port = listener.protocol_port
+            listener = self.neutron.hm_get_listener(context, hm)
+            kwargs["port"] = listener.protocol_port
         except:
             LOG.warn("Listener for HM could not be located")
 

--- a/a10_neutron_lbaas/v2/handler_hm.py
+++ b/a10_neutron_lbaas/v2/handler_hm.py
@@ -59,6 +59,13 @@ class HealthMonitorHandler(handler_base_v2.HandlerBaseV2):
 
     def _create(self, c, context, hm, **kwargs):
         try:
+            listener = self.neutron_ops.hm_get_listener(context, hm)
+            hm.port = listener.protocol_port
+        except:
+            LOG.warn("Listener for HM could not be located")
+
+        # Send listener port to acos create
+        try:
             self._set(c, c.client.slb.hm.create, context, hm, **kwargs)
         except acos_errors.Exists:
             pass

--- a/a10_neutron_lbaas/v2/neutron_ops.py
+++ b/a10_neutron_lbaas/v2/neutron_ops.py
@@ -56,8 +56,6 @@ class NeutronOpsV2(object):
 
         return pool.listener
 
-        
-
     def bcm_factory(self):
         from neutron_lbaas.services.loadbalancer.plugin import CERT_MANAGER_PLUGIN
         return CERT_MANAGER_PLUGIN.CertManager()

--- a/a10_neutron_lbaas/v2/neutron_ops.py
+++ b/a10_neutron_lbaas/v2/neutron_ops.py
@@ -20,7 +20,6 @@ except ImportError:
     # v2 does not exist before Kilo
     pass
 
-
 class NeutronOpsV2(object):
 
     def __init__(self, handler):
@@ -48,6 +47,16 @@ class NeutronOpsV2(object):
 
     def pool_get(self, context, pool_id):
         return self.plugin.db.get_pool(context, pool_id)
+
+    def hm_get_listener(self, context, hm):
+        # get the pool attached to the HM
+        pool_id = hm.pool_id
+        pool_qry = context.session.query(lb_db.PoolV2)
+        pool = pool_qry.filter_by(id=pool_id).first()
+
+        return pool.listener
+
+        
 
     def bcm_factory(self):
         from neutron_lbaas.services.loadbalancer.plugin import CERT_MANAGER_PLUGIN

--- a/a10_neutron_lbaas/v2/neutron_ops.py
+++ b/a10_neutron_lbaas/v2/neutron_ops.py
@@ -50,7 +50,7 @@ class NeutronOpsV2(object):
 
     def hm_get_listener(self, context, hm):
         # get the pool attached to the HM
-        pool_id = hm.pool_id
+        pool_id = hm.pool.id
         pool_qry = context.session.query(lb_db.PoolV2)
         pool = pool_qry.filter_by(id=pool_id).first()
 


### PR DESCRIPTION
Creates HM with port of pool -> listener hierarchy instead of relying on HM port type.
Port type is still considered for HM method parameter