### PR TITLE
[OM-92] Isolate DB tests in test environment for Travis CI compatibility

### DIFF
--- a/a10_neutron_lbaas/tests/db/migration/test_base.py
+++ b/a10_neutron_lbaas/tests/db/migration/test_base.py
@@ -12,11 +12,12 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.from neutron.db import model_base
 
+from nose.plugins.attrib import attr
 import sqlalchemy.orm
 
 from a10_neutron_lbaas.tests.db import test_base
 
-
+@attr(db=True)
 class UnitTestBase(test_base.DbTestBase):
 
     def setUp(self):

--- a/a10_neutron_lbaas/tests/db/migration/test_migrations.py
+++ b/a10_neutron_lbaas/tests/db/migration/test_migrations.py
@@ -16,6 +16,8 @@ import copy
 import mock
 import os
 
+from nose.plugins.attrib import attr
+
 import alembic.command as alembic_command
 import alembic.config as alembic_config
 import alembic.op as op
@@ -26,6 +28,7 @@ import a10_neutron_lbaas.tests.db.session as session
 import test_base
 
 
+@attr(db=True)
 class TestMigrations(test_base.UnitTestBase):
 
     def setUp(self):

--- a/a10_neutron_lbaas/tests/db/neutron_ext/db/test_certificates.py
+++ b/a10_neutron_lbaas/tests/db/neutron_ext/db/test_certificates.py
@@ -18,6 +18,8 @@ from a10_neutron_lbaas.neutron_ext.common import constants
 from a10_neutron_lbaas.neutron_ext.db import certificate_db as certs_db
 from a10_neutron_lbaas.tests.db import test_base as tbase
 
+from nose.plugins.attrib import attr
+
 import mock
 from neutron.plugins.common import constants as nconstants
 from neutron.tests.unit.api.v2 import test_base as ntbase
@@ -210,6 +212,7 @@ CERTIFICATE_EXT = "a10-certificate"
 #         self.plugin.delete_a10_certificate_binding.assert_called_with(mock.ANY, binding_id)
 
 
+@attr(db=True)
 class CertificateDbMixInTestCase(tbase.UnitTestBase):
 
     """Tests a10_openstack.neutron_ext.db.certificate_db.CertificateManager"""

--- a/a10_neutron_lbaas/tests/db/test_a10_context.py
+++ b/a10_neutron_lbaas/tests/db/test_a10_context.py
@@ -13,6 +13,7 @@
 #    under the License.from neutron.db import model_base
 
 import mock
+from nose.plugins.attrib import attr
 
 import a10_neutron_lbaas.tests.unit.test_a10_openstack_lb as test_a10_openstack_lb
 import test_base
@@ -21,6 +22,7 @@ import a10_neutron_lbaas.a10_context as a10_context
 import a10_neutron_lbaas.vthunder.instance_manager as instance_manager
 
 
+@attr(db=True)
 class TestA10Context(test_a10_openstack_lb.SetupA10OpenstackLBBase, test_base.UnitTestBase):
 
     def setUp(self):

--- a/a10_neutron_lbaas/tests/db/test_a10_tenant_bindings.py
+++ b/a10_neutron_lbaas/tests/db/test_a10_tenant_bindings.py
@@ -13,6 +13,7 @@
 #    under the License.
 
 import datetime
+from nose.plugins.attrib import attr
 
 from a10_neutron_lbaas.db import models
 
@@ -20,7 +21,7 @@ import test_base
 
 dt = datetime.datetime.fromtimestamp(1458346727)
 
-
+@attr(db=True)
 class TestTenantBindings(test_base.UnitTestBase):
 
     def test_model_create(self):

--- a/a10_neutron_lbaas/tests/db/test_base.py
+++ b/a10_neutron_lbaas/tests/db/test_base.py
@@ -14,6 +14,7 @@
 
 import os
 
+from nose.plugins.attrib import attr
 import sqlalchemy
 from sqlalchemy.engine.url import make_url
 from sqlalchemy.orm import sessionmaker
@@ -22,6 +23,7 @@ from a10_neutron_lbaas.tests.db import session
 from a10_neutron_lbaas.tests import test_case
 
 
+@attr(db=True)
 class DbTestBase(test_case.TestCase):
 
     def setUp(self):

--- a/a10_neutron_lbaas/tests/db/test_select_device_db.py
+++ b/a10_neutron_lbaas/tests/db/test_select_device_db.py
@@ -12,6 +12,8 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+from nose.plugins.attrib import attr
+
 import acos_client
 
 from a10_neutron_lbaas.db import models
@@ -44,6 +46,7 @@ EXPECTED_DEV2 = acos_client.Hash(devices2.keys()).get_server(TENANT_ID)
 HARDCODE_RESULT2 = 'dev2'
 
 
+@attr(db=True)
 class TestSelectDevice(test_base.UnitTestBase):
 
     def test_test_setup(self):

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,11 @@ install_command = pip install -U {opts} {packages}
 deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
 commands =
-  pifpaf run mysql -- nosetests {posargs}
+  nosetests {posargs} -a '!db'
+
+[testenv:db]
+commands = 
+  pifpaf run mysql -- nosetests {posargs} -a db
 
 [testenv:pep8]
 commands =


### PR DESCRIPTION
This adds attributes to the DB tests so they can be run independently of unit tests on Travis CI. Travis lacks the pifpaf/mysql combination necessary for running the tests.

This doesn't affect the passing nature of any tests.