### PR TITLE
Template support for all SLB nouns - OM89

### DIFF
--- a/a10_neutron_lbaas/tests/unit/v2/test_handler_lb.py
+++ b/a10_neutron_lbaas/tests/unit/v2/test_handler_lb.py
@@ -111,6 +111,54 @@ class TestLB(test_base.HandlerTestBase):
     def test_create_default_vrid_set_v30_with_template(self):
         self._test_create_template_virtual_server("3.0", "testTemplate")
 
+    def _test_create_virtual_server_templates(self, api_ver="3.0", virtual_server_templates=None, update=False):
+        for k, v in self.a.config.get_devices().items():
+            v['api_version'] = api_ver
+            v['templates'] = virtual_server_templates
+
+        lb = fake_objs.FakeLoadBalancer()
+        if update:
+            self.a.lb.update(None, lb, lb)
+            create = self.a.last_client.slb.virtual_server.update
+        else:
+            self.a.lb.create(None, lb)
+            create = self.a.last_client.slb.virtual_server.create
+        create.assert_has_calls([mock.ANY])
+        calls = create.call_args_list
+        if virtual_server_templates is not None:
+            self.assertIn('test-template-virtual-server', str(calls))
+            self.assertIn('test-template-logging', str(calls))
+            self.assertIn('test-policy', str(calls))
+        if virtual_server_templates is None:
+            foundVrid = any(
+                'virtual_server_templates' in x.get('axapi_args', {}).get('virtual_server', {})
+                for (_, x) in calls)
+            self.assertFalse(
+                foundVrid,
+                'Expected to find no virtual_server_templates in {0}'.format(str(calls)))
+
+    def test_create_with_template_virtual_server(self):
+        template = {
+            "virtual-server": {
+                "template-virtual-server": "test-template-virtual-server",
+                "template-logging": "test-template-logging",
+                "template-policy": "test-policy",
+                "template-scaleout": "test-scaleout",
+            }
+        }
+        self._test_create_virtual_server_templates("3.0", virtual_server_templates=template)
+
+    def test_update_with_template_virtual_server(self):
+        template = {
+            "virtual-server": {
+                "template-virtual-server": "test-template-virtual-server",
+                "template-logging": "test-template-logging",
+                "template-policy": "test-policy",
+                "template-scaleout": "test-scaleout",
+            }
+        }
+        self._test_create_virtual_server_templates("3.0", virtual_server_templates=template, update=True)
+
     # There's no code that causes listeners to be added
     # if they are present when the pool is created.
     # We'd use unittest.skip if it worked with cursed 2.6

--- a/a10_neutron_lbaas/tests/unit/v2/test_handler_lb.py
+++ b/a10_neutron_lbaas/tests/unit/v2/test_handler_lb.py
@@ -111,7 +111,8 @@ class TestLB(test_base.HandlerTestBase):
     def test_create_default_vrid_set_v30_with_template(self):
         self._test_create_template_virtual_server("3.0", "testTemplate")
 
-    def _test_create_virtual_server_templates(self, api_ver="3.0", virtual_server_templates=None, update=False):
+    def _test_create_virtual_server_templates(self, api_ver="3.0", virtual_server_templates=None,
+                                              update=False):
         for k, v in self.a.config.get_devices().items():
             v['api_version'] = api_ver
             v['templates'] = virtual_server_templates
@@ -157,7 +158,8 @@ class TestLB(test_base.HandlerTestBase):
                 "template-scaleout": "test-scaleout",
             }
         }
-        self._test_create_virtual_server_templates("3.0", virtual_server_templates=template, update=True)
+        self._test_create_virtual_server_templates("3.0", virtual_server_templates=template,
+                                                   update=True)
 
     # There's no code that causes listeners to be added
     # if they are present when the pool is created.

--- a/a10_neutron_lbaas/tests/unit/v2/test_handler_lb.py
+++ b/a10_neutron_lbaas/tests/unit/v2/test_handler_lb.py
@@ -111,8 +111,8 @@ class TestLB(test_base.HandlerTestBase):
     def test_create_default_vrid_set_v30_with_template(self):
         self._test_create_template_virtual_server("3.0", "testTemplate")
 
-    def _test_create_virtual_server_templates(self, api_ver="3.0", virtual_server_templates=None,
-                                              update=False):
+    def _test_create_virtual_server_templates(self, api_ver="3.0",
+                                              virtual_server_templates=None, update=False):
         for k, v in self.a.config.get_devices().items():
             v['api_version'] = api_ver
             v['templates'] = virtual_server_templates
@@ -158,7 +158,8 @@ class TestLB(test_base.HandlerTestBase):
                 "template-scaleout": "test-scaleout",
             }
         }
-        self._test_create_virtual_server_templates("3.0", virtual_server_templates=template,
+        self._test_create_virtual_server_templates("3.0",
+                                                   virtual_server_templates=template,
                                                    update=True)
 
     # There's no code that causes listeners to be added

--- a/a10_neutron_lbaas/tests/unit/v2/test_handler_member.py
+++ b/a10_neutron_lbaas/tests/unit/v2/test_handler_member.py
@@ -84,6 +84,7 @@ class TestMembers(test_base.HandlerTestBase):
             name, ip,
             status=status,
             config_defaults=mock.ANY,
+            server_templates=None,
             axapi_args={'server': server_args})
         self.a.last_client.slb.service_group.member.create.assert_called_with(
             m.pool.id, name, m.protocol_port, status=status,
@@ -181,6 +182,7 @@ class TestMembers(test_base.HandlerTestBase):
             mock.ANY,
             mock.ANY,
             status=mock.ANY,
+            server_templates=None,
             config_defaults=expected,
             axapi_args={'server': {}})
         # self.assertIn("member.create", s)
@@ -213,6 +215,7 @@ class TestMembers(test_base.HandlerTestBase):
         self.a.last_client.slb.server.create.assert_called_with(
             mock.ANY, mock.ANY,
             status=mock.ANY,
+            server_templates=None,
             config_defaults={},
             axapi_args={'server': {}})
 
@@ -231,5 +234,25 @@ class TestMembers(test_base.HandlerTestBase):
         self.a.last_client.slb.server.create.assert_called_with(
             mock.ANY, mock.ANY,
             status=mock.ANY,
+            server_templates=None,
             config_defaults={},
+            axapi_args={'server': {}})
+
+    def test_create_with_template(self,):
+        template = {
+            "server": {
+                "template-server": "sg1"
+            }
+        }
+        expect = {'template-server': 'sg1'}
+        for k, v in self.a.config.get_devices().items():
+            v['templates'] = template
+        m = fake_objs.FakeMember(admin_state_up=True,
+                                 pool=mock.MagicMock())
+        self.a.member.create(None, m)
+        self.a.last_client.slb.server.create.assert_called_with(
+            mock.ANY, mock.ANY,
+            status=mock.ANY,
+            config_defaults=mock.ANY,
+            server_templates=expect,
             axapi_args={'server': {}})

--- a/a10_neutron_lbaas/tests/unit/v2/test_handler_member.py
+++ b/a10_neutron_lbaas/tests/unit/v2/test_handler_member.py
@@ -83,8 +83,8 @@ class TestMembers(test_base.HandlerTestBase):
         self.a.last_client.slb.server.create.assert_called_with(
             name, ip,
             status=status,
-            config_defaults=mock.ANY,
             server_templates=None,
+            config_defaults=mock.ANY,
             axapi_args={'server': server_args})
         self.a.last_client.slb.service_group.member.create.assert_called_with(
             m.pool.id, name, m.protocol_port, status=status,

--- a/a10_neutron_lbaas/tests/unit/v2/test_handler_member.py
+++ b/a10_neutron_lbaas/tests/unit/v2/test_handler_member.py
@@ -76,10 +76,10 @@ class TestMembers(test_base.HandlerTestBase):
         server_args = {}
         if conn_limit is not None:
             if conn_limit > 0 and conn_limit <= 8000000:
-                server_args['conn_limit'] = conn_limit
+                server_args['conn-limit'] = conn_limit
         if conn_resume is not None:
             if conn_resume > 0 and conn_resume <= 1000000:
-                server_args['conn_resume'] = conn_resume
+                server_args['conn-resume'] = conn_resume
         self.a.last_client.slb.server.create.assert_called_with(
             name, ip,
             status=status,

--- a/a10_neutron_lbaas/tests/unit/v2/test_handler_pool.py
+++ b/a10_neutron_lbaas/tests/unit/v2/test_handler_pool.py
@@ -96,7 +96,7 @@ class TestPools(test_base.HandlerTestBase):
             "template-server": "sg1",
             "template-port": "sg1",
             "template-policy": "sg1"
-            }
+        }
         for k, v in self.a.config.get_devices().items():
             v['templates'] = template
 
@@ -139,7 +139,7 @@ class TestPools(test_base.HandlerTestBase):
             "template-server": "sg1",
             "template-port": "sg1",
             "template-policy": "sg1"
-            }
+        }
         for k, v in self.a.config.get_devices().items():
             v['templates'] = template
 

--- a/a10_neutron_lbaas/tests/unit/v2/test_handler_pool.py
+++ b/a10_neutron_lbaas/tests/unit/v2/test_handler_pool.py
@@ -84,6 +84,34 @@ class TestPools(test_base.HandlerTestBase):
                                 cookie_persistence.create.
                                 assert_called_with(pool.id))
 
+    def test_create_with_template(self):
+        template = {
+            "service-group": {
+                "template-server": "sg1",
+                "template-port": "sg1",
+                "template-policy": "sg1"
+            }
+        }
+        exp_template = {
+            "template-server": "sg1",
+            "template-port": "sg1",
+            "template-policy": "sg1"
+            }
+        for k, v in self.a.config.get_devices().items():
+            v['templates'] = template
+
+        pers1 = None
+        pool = fake_objs.FakePool('TCP', 'ROUND_ROBIN', pers1, True)
+
+        self.a.pool.create(None, pool)
+        self.a.last_client.slb.service_group.create.assert_called_with(
+            pool.id,
+            axapi_args={"service_group": {}},
+            lb_method=mock.ANY,
+            config_defaults=mock.ANY,
+            protocol=mock.ANY,
+            service_group_templates=exp_template)
+
     def test_update(self):
         pers1 = None
         pers2 = None
@@ -96,7 +124,38 @@ class TestPools(test_base.HandlerTestBase):
             axapi_args={"service_group": {}},
             lb_method=mock.ANY,
             config_defaults=mock.ANY,
-            protocol=mock.ANY)
+            protocol=mock.ANY,
+            service_group_templates=None)
+
+    def test_update_with_template(self):
+        template = {
+            "service-group": {
+                "template-server": "sg1",
+                "template-port": "sg1",
+                "template-policy": "sg1"
+            }
+        }
+        exp_template = {
+            "template-server": "sg1",
+            "template-port": "sg1",
+            "template-policy": "sg1"
+            }
+        for k, v in self.a.config.get_devices().items():
+            v['templates'] = template
+
+        pers1 = None
+        pers2 = None
+        old_pool = fake_objs.FakePool('TCP', 'LEAST_CONNECTIONS', pers1, True)
+        pool = fake_objs.FakePool('TCP', 'ROUND_ROBIN', pers2, True)
+        self.a.pool.update(None, pool, old_pool)
+
+        self.a.last_client.slb.service_group.update.assert_called_with(
+            pool.id,
+            axapi_args={"service_group": {}},
+            lb_method=mock.ANY,
+            config_defaults=mock.ANY,
+            protocol=mock.ANY,
+            service_group_templates=exp_template)
 
     def test_delete(self):
         members = [[], [fake_objs.FakeMember()]]

--- a/a10_neutron_lbaas/v2/handler_lb.py
+++ b/a10_neutron_lbaas/v2/handler_lb.py
@@ -29,6 +29,12 @@ class LoadbalancerHandler(handler_base_v2.HandlerBaseV2):
         if not lb.admin_state_up:
             status = c.client.slb.DOWN
 
+        conf_templates = c.device_cfg.get('templates')
+        if conf_templates:
+            virtual_server_templates = conf_templates.get("virtual-server", None)
+        else:
+            virtual_server_templates = None
+
         try:
             vip_meta = self.meta(lb, 'virtual_server', {})
             os_name = lb.name
@@ -38,6 +44,7 @@ class LoadbalancerHandler(handler_base_v2.HandlerBaseV2):
                 arp_disable=c.device_cfg.get('arp_disable'),
                 status=status,
                 vrid=c.device_cfg.get('default_virtual_server_vrid'),
+                virtual_server_templates=virtual_server_templates,
                 template_virtual_server=c.device_cfg.get('template-virtual-server'),
                 config_defaults=self._get_config_defaults(c, os_name),
                 axapi_body=vip_meta)

--- a/a10_neutron_lbaas/v2/handler_listener.py
+++ b/a10_neutron_lbaas/v2/handler_listener.py
@@ -174,6 +174,12 @@ class ListenerHandler(handler_base_v2.HandlerBaseV2):
         if "no-dest-nat" in template_args and protocol.lower() in ("http", "https"):
             del template_args["no-dest-nat"]
 
+        conf_templates = c.device_cfg.get('templates')
+        if conf_templates:
+            virtual_port_templates = conf_templates.get("virtual-port", None)
+        else:
+            virtual_port_templates = None
+
         try:
 
             set_method(
@@ -192,6 +198,7 @@ class ListenerHandler(handler_base_v2.HandlerBaseV2):
                 no_dest_nat=c.device_cfg.get('no-dest-nat'),
                 conn_limit=c.device_cfg.get('conn-limit'),
                 # Device-level defaults
+                virtual_port_templates=virtual_port_templates,
                 vport_defaults=vport_defaults,
                 axapi_body=vport_meta,
                 **template_args)

--- a/a10_neutron_lbaas/v2/handler_member.py
+++ b/a10_neutron_lbaas/v2/handler_member.py
@@ -65,14 +65,14 @@ class MemberHandler(handler_base_v2.HandlerBaseV2):
                                 "bounds with value {0}. Please set to between " +
                                 "1-8000000. Defaulting to 8000000".format(conn_limit))
                 else:
-                    server_args['conn_limit'] = conn_limit
+                    server_args['conn-limit'] = conn_limit
 
             if conn_resume is not None:
                 if conn_resume < 1 or conn_resume > 1000000:
                     LOG.warning("The specified conn_resume value is invalid. \
                     The value should be either 0 or 1")
                 else:
-                    server_args['conn_resume'] = conn_resume
+                    server_args['conn-resume'] = conn_resume
 
             server_args = {'server': server_args}
 

--- a/a10_neutron_lbaas/v2/handler_member.py
+++ b/a10_neutron_lbaas/v2/handler_member.py
@@ -76,8 +76,15 @@ class MemberHandler(handler_base_v2.HandlerBaseV2):
 
             server_args = {'server': server_args}
 
+            conf_templates = c.device_cfg.get('templates')
+            if conf_templates:
+                server_templates = conf_templates.get("server", None)
+            else:
+                server_templates = None
+
             c.client.slb.server.create(server_name, server_ip,
                                        status=status,
+                                       server_templates=server_templates,
                                        config_defaults=self._get_config_defaults(c, os_name),
                                        axapi_args=server_args)
 

--- a/a10_neutron_lbaas/v2/handler_pool.py
+++ b/a10_neutron_lbaas/v2/handler_pool.py
@@ -30,10 +30,18 @@ class PoolHandler(handler_base_v2.HandlerBaseV2):
         self._update_session_persistence(old_pool, pool, c, context)
         args = {'service_group': self.meta(pool, 'service_group', {})}
         os_name = pool.name
+
+        conf_templates = c.device_cfg.get('templates')
+        if conf_templates:
+            service_group_templates = conf_templates.get("service-group", None)
+        else:
+            service_group_templates = None
+
         set_method(
             self._meta_name(pool),
             protocol=openstack_mappings.service_group_protocol(c, pool.protocol),
             lb_method=openstack_mappings.service_group_lb_method(c, pool.lb_algorithm),
+            service_group_templates=service_group_templates,
             config_defaults=self._get_config_defaults(c, os_name),
             axapi_args=args)
 


### PR DESCRIPTION
added changes to accept templates from config file as a single JSON
Example: devices = {
    "ax1": {
        "name": "ax1",
        "host": "10.43.12.122",
        "port": 443,
        "username": "admin",
        "password": "a10",
        "autosnat": True,
        "api_version": "3.0",
        "conn-limit": "9000",
        "conn-resume": 40000,
        "no-dest-nat": 1,
        "template-virtual-server": "omkar2",
        "templates": {
           "virtual-server":{
           "template-virtual-server":"sg2",
           "template-logging" : "sg2",
           "template-policy": "sg2",
           "template-scaleout" : "",
           },
           "virtual-port":{
           "template-virtual-port": "sg2",
           "template-tcp": "sg2",
           "template-policy": "sg2",
           "template-scaleout": ""
           },
           "service-group":{
           "template-server": "sg2",
           "template-port": "sg2",
           "template-policy" : "sg2"
           },
           "server":{
           "template-server":"sg2"
           }
        }
    }
}