### PR TITLE
STACK-87 OM-111 - backward compatibility for Mitaka/liberty

### DIFF
--- a/a10_neutron_lbaas/neutron_ext/extensions/a10DeviceInstance.py
+++ b/a10_neutron_lbaas/neutron_ext/extensions/a10DeviceInstance.py
@@ -51,8 +51,9 @@ _ALIAS = constants.A10_DEVICE_INSTANCE_EXT
 # TODO(rename this to *Extension to avoid config file confusion)
 class A10deviceinstance(extensions.ExtensionDescriptor):
 
-    nextensions.register_custom_supported_check(
-        _ALIAS, lambda: True, plugin_agnostic=True)
+    if hasattr(nextensions, 'register_custom_supported_check'):
+        nextensions.register_custom_supported_check(
+            _ALIAS, lambda: True, plugin_agnostic=True)
 
     def get_name(cls):
         return "A10 Device Instances"


### PR DESCRIPTION
STACK-87 OM-111 backward compatibility for Mitaka/liberty
Files changed: 
a10_neutron_lbaas/neutron_ext/extensions/a10DeviceInstance.py

Resolving error that occurs in Mitaka/Liberty version due to missing "register_custom_supported_check" function. Checking the existence of function before call using 'hasattr'