### PR TITLE
[STACK-168] Correct duplicate argument issue in listener update

### DIFF
--- a/a10_neutron_lbaas/tests/unit/v2/test_base.py
+++ b/a10_neutron_lbaas/tests/unit/v2/test_base.py
@@ -33,6 +33,7 @@ class HandlerTestBase(UnitTestBase):
         self.EXPR_END = "end"
         self.EXPR_CLASS = "charclass"
         self.EXPR_PROTOCOL = "protocol"
+        self.EXPR_PARAMS = "params"
 
     def _get_expressions_mock(self):
         return {
@@ -59,6 +60,14 @@ class HandlerTestBase(UnitTestBase):
                 "regex": "^protocol",
                 "json": {
                     "protocol": "tcp"
+                }
+            },
+            self.EXPR_PARAMS: {
+                "regex": "^params",
+                "json": {
+                    "protocol": "tcp",
+                    "ipinip": 1,
+                    "autosnat": 1
                 }
             }
         }

--- a/a10_neutron_lbaas/tests/unit/v2/test_base.py
+++ b/a10_neutron_lbaas/tests/unit/v2/test_base.py
@@ -32,6 +32,7 @@ class HandlerTestBase(UnitTestBase):
         self.EXPR_BEGIN = "beginning"
         self.EXPR_END = "end"
         self.EXPR_CLASS = "charclass"
+        self.EXPR_PROTOCOL = "protocol"
 
     def _get_expressions_mock(self):
         return {
@@ -52,6 +53,12 @@ class HandlerTestBase(UnitTestBase):
                 "regex": "[w]{2,3}",
                 "json": {
                     "scaleout-bucket-count": 64
+                }
+            },
+            self.EXPR_PROTOCOL: {
+                "regex": "^protocol",
+                "json": {
+                    "protocol": "tcp"
                 }
             }
         }

--- a/a10_neutron_lbaas/tests/unit/v2/test_handler_listener.py
+++ b/a10_neutron_lbaas/tests/unit/v2/test_handler_listener.py
@@ -559,3 +559,21 @@ class TestListeners(test_base.HandlerTestBase):
         self.assertIn("vport.create", s)
         self.assertIn("protocol='tcp'", s)
 
+    def test_create_vport_expressions_overrides_protocol(self):
+        # Duplicated because this is a slightly different test.
+        pattern = "params"
+        self.a.config.get_vport_expressions = self._get_expressions_mock
+        expressions = self.a.config.get_vport_expressions()
+        expected = expressions.get(pattern, {}).get("json", {})
+        p = 'UDP'
+        lb = fake_objs.FakeLoadBalancer()
+        pool = fake_objs.FakePool(p, 'ROUND_ROBIN', None)
+        m = fake_objs.FakeListener(p, 2222, pool=pool,
+                                   loadbalancer=lb)
+        m.name = pattern
+        handler = self.a.listener
+        handler.create(None, m)
+
+        s = str(self.a.last_client.mock_calls)
+        self.assertIn("vport.create", s)
+        self.assertIn("protocol='tcp'", s)

--- a/a10_neutron_lbaas/tests/unit/v2/test_handler_listener.py
+++ b/a10_neutron_lbaas/tests/unit/v2/test_handler_listener.py
@@ -540,5 +540,22 @@ class TestListeners(test_base.HandlerTestBase):
         handler.create(None, m)
         # This test should just run without raising any exceptions
 
-    def test_create_vport_expressions_match_beginning(self):
-        self._test_create_expressions("protocol", self.EXPR_PROTOCOL)
+    def test_create_vport_expressions_doesnt_break_acos_args(self):
+        # Duplicated because this is a slightly different test.
+        pattern = "params"
+        self.a.config.get_vport_expressions = self._get_expressions_mock
+        expressions = self.a.config.get_vport_expressions()
+        expected = expressions.get(pattern, {}).get("json", {})
+        p = 'TCP'
+        lb = fake_objs.FakeLoadBalancer()
+        pool = fake_objs.FakePool(p, 'ROUND_ROBIN', None)
+        m = fake_objs.FakeListener(p, 2222, pool=pool,
+                                   loadbalancer=lb)
+        m.name = pattern 
+        handler = self.a.listener
+        handler.create(None, m)
+
+        s = str(self.a.last_client.mock_calls)
+        self.assertIn("vport.create", s)
+        self.assertIn("protocol='tcp'", s)
+

--- a/a10_neutron_lbaas/tests/unit/v2/test_handler_listener.py
+++ b/a10_neutron_lbaas/tests/unit/v2/test_handler_listener.py
@@ -539,3 +539,6 @@ class TestListeners(test_base.HandlerTestBase):
         handler = self.a.listener
         handler.create(None, m)
         # This test should just run without raising any exceptions
+
+    def test_create_vport_expressions_match_beginning(self):
+        self._test_create_expressions("protocol", self.EXPR_PROTOCOL)

--- a/a10_neutron_lbaas/tests/unit/v2/test_handler_listener.py
+++ b/a10_neutron_lbaas/tests/unit/v2/test_handler_listener.py
@@ -544,14 +544,12 @@ class TestListeners(test_base.HandlerTestBase):
         # Duplicated because this is a slightly different test.
         pattern = "params"
         self.a.config.get_vport_expressions = self._get_expressions_mock
-        expressions = self.a.config.get_vport_expressions()
-        expected = expressions.get(pattern, {}).get("json", {})
         p = 'TCP'
         lb = fake_objs.FakeLoadBalancer()
         pool = fake_objs.FakePool(p, 'ROUND_ROBIN', None)
         m = fake_objs.FakeListener(p, 2222, pool=pool,
                                    loadbalancer=lb)
-        m.name = pattern 
+        m.name = pattern
         handler = self.a.listener
         handler.create(None, m)
 
@@ -563,8 +561,6 @@ class TestListeners(test_base.HandlerTestBase):
         # Duplicated because this is a slightly different test.
         pattern = "params"
         self.a.config.get_vport_expressions = self._get_expressions_mock
-        expressions = self.a.config.get_vport_expressions()
-        expected = expressions.get(pattern, {}).get("json", {})
         p = 'UDP'
         lb = fake_objs.FakeLoadBalancer()
         pool = fake_objs.FakePool(p, 'ROUND_ROBIN', None)

--- a/a10_neutron_lbaas/v2/handler_listener.py
+++ b/a10_neutron_lbaas/v2/handler_listener.py
@@ -149,7 +149,9 @@ class ListenerHandler(handler_base_v2.HandlerBaseV2):
 
         # This doesn't do anything anymore.
         vport_meta = self.meta(listener.loadbalancer, 'vip_port', {})
-        template_args.update(**self._get_vport_defaults(c, os_name))
+
+        # TODO(mdurrant): This breaks if we introduce non-template args
+        # template_args.update(**self._get_vport_defaults(c, os_name))
 
         vport_defaults = self._get_vport_defaults(c, os_name)
 
@@ -176,6 +178,11 @@ class ListenerHandler(handler_base_v2.HandlerBaseV2):
 
         if hasattr(listener, 'aflex'):
             template_args["aflex-scripts"] = listener.aflex
+
+        if "protocol" in vport_defaults:
+            # import pdb; pdb.set_trace()
+            protocol = vport_defaults["protocol"]
+            del vport_defaults["protocol"]
 
         conf_templates = c.device_cfg.get('templates')
         if conf_templates:

--- a/a10_neutron_lbaas/v2/handler_listener.py
+++ b/a10_neutron_lbaas/v2/handler_listener.py
@@ -180,7 +180,6 @@ class ListenerHandler(handler_base_v2.HandlerBaseV2):
             template_args["aflex-scripts"] = listener.aflex
 
         if "protocol" in vport_defaults:
-            # import pdb; pdb.set_trace()
             protocol = vport_defaults["protocol"]
             del vport_defaults["protocol"]
 


### PR DESCRIPTION
Corrects issue reported by customer when `protocol` is specified in virtual port expressions.