### PR TITLE
Revert "Fixed incorrect mapping of HTTPS to TCP"

### DIFF
--- a/a10_neutron_lbaas/acos/openstack_mappings.py
+++ b/a10_neutron_lbaas/acos/openstack_mappings.py
@@ -67,7 +67,7 @@ def vip_protocols(c, os_protocol):
         'TCP': z.TCP,
         'UDP': z.UDP,
         'HTTP': z.HTTP,
-        'HTTPS': z.HTTPS,
+        'HTTPS': z.TCP,
         'TERMINATED_HTTPS': z.HTTPS,
         'OTHERS': z.OTHERS,
         'RTSP': z.RTSP,


### PR DESCRIPTION
Reverts a10networks/a10-neutron-lbaas#465

Realized that Openstack treats HTTPS as raw TCP traffic which makes sense. Don't know what I thought this was a good change. It was made to patch a bug but it was done in the wrong place.