### PR TITLE
[STACK-1252] Updated requirements to match current reqs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 a10-openstack-lib>=0.2.1
-acos-client>=1.4.6
+acos-client>=2.0.0
 debtcollector
 netaddr
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,7 +3,7 @@ hacking>=0.10,<0.11
 mock>=1.0.1,<1.1.0
 mox
 mox3
--e git+https://github.com/openstack/neutron-lbaas#egg=neutron-lbaas
+-e git+https://github.com/openstack/neutron-lbaas/tree/stable/stein#egg=neutron-lbaas
 #neutron
 #neutron-lbaas
 nose
@@ -16,4 +16,4 @@ pymysql
 testresources
 testscenarios
 # TODO(dougwig) -- can we remove this?
--e git+https://github.com/openstack/neutron#egg=neutron
+-e git+https://github.com/openstack/neutron/tree/stable/stein#egg=neutron

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,9 +3,7 @@ hacking>=0.10,<0.11
 mock>=1.0.1,<1.1.0
 mox
 mox3
--e git+https://github.com/openstack/neutron-lbaas/tree/stable/stein#egg=neutron-lbaas
-#neutron
-#neutron-lbaas
+neutron-lbaas>=14.0.0,<15.0.0
 nose
 nose-exclude
 oslotest
@@ -15,5 +13,4 @@ pifpaf
 pymysql
 testresources
 testscenarios
-# TODO(dougwig) -- can we remove this?
--e git+https://github.com/openstack/neutron/tree/stable/stein#egg=neutron
+neutron>=14.0.0,<15.0.0


### PR DESCRIPTION
Install stein version only to test against for unit tests. Stein is the last version which contains neutron-lbaas. (We are at Ussuri release at the time of writing this).